### PR TITLE
Ensure references separated by semicolon include book

### DIFF
--- a/creeds/first_confession_of_basel.json
+++ b/creeds/first_confession_of_basel.json
@@ -29,7 +29,7 @@
         },
         {
           "Id": 2,
-          "References": ["Rom. 8:28; 9:6; 11:5; Eph. 1:4"]
+          "References": ["Rom. 8:28; Rom. 9:6; Rom. 11:5; Eph. 1:4"]
         }
       ],
       "ProofsWithScripture": [
@@ -39,7 +39,7 @@
         },
         {
           "Id": 2,
-          "References": ["Rom. 8:28 ff.; 9:6 ff.; 11:5 ff.; Eph. 1:4 ff."]
+          "References": ["Rom. 8:28 ff.; Rom. 9:6 ff.; Rom. 11:5 ff.; Eph. 1:4 ff."]
         }
       ]
     },
@@ -51,13 +51,13 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Gen. 1:26; Eph. 4:21; Gen. 8:6; 5:3; Rom. 5:12, 15; I Cor.  15:21; Eph. 2:1; Gen. 6:5; 8:21; John 3:3; Rom. 3:10, 23; Ps. 143:2, 10; Eph. 2:1"]
+          "References": ["Gen. 1:26; Eph. 4:21; Gen. 8:6; Gen. 5:3; Rom. 5:12, 15; I Cor.  15:21; Eph. 2:1; Gen. 6:5; Gen. 8:21; John 3:3; Rom. 3:10, 23; Ps. 143:2, 10; Eph. 2:1"]
         }
       ],
       "ProofsWithScripture": [
         {
           "Id": 1,
-          "References": ["Gen. 1:26; Eph. 4:21; Gen. 8:6; 5:3; Rom. 5:12, 15 ff.: I Cor.  15:21 f.; Eph. 2:1 ff.; Gen. 6:5; 8:21; John 3:3 ff.; Rom. 3:10 ff., 23; Ps. 143:2, 10; Eph. 2:1 ff."]
+          "References": ["Gen. 1:26; Eph. 4:21; Gen. 8:6; Gen. 5:3; Rom. 5:12, 15 ff.; I Cor.  15:21 f.; Eph. 2:1 ff.; Gen. 6:5; Gen. 8:21; John 3:3 ff.; Rom. 3:10 ff., 23; Ps. 143:2, 10; Eph. 2:1 ff."]
         }
       ]
     },
@@ -69,13 +69,13 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Rom. 5:16; Gen. 3:15; 21:15; 26:3-4, 24; 28:13"]
+          "References": ["Rom. 5:16; Gen. 3:15; Gen. 21:15; Gen. 26:3-4, 24; Gen. 28:13"]
         }
       ],
       "ProofsWithScripture": [
         {
           "Id": 1,
-          "References": ["Rom. 5:16; Gen. 3:15; 21:15; 26:3-4, 24; 28:13"]
+          "References": ["Rom. 5:16; Gen. 3:15; Gen. 21:15; Gen. 26:3-4, 24; Gen. 28:13"]
         }
       ]
     },
@@ -91,7 +91,7 @@
         },
         {
           "Id": 2,
-          "References": ["Matt. 1:18; Luke 1:35; 2:7; Matt. 20:28; 26:28; Rom. 5:6; I Cor. 15:3; 1 Peter 2:24; Heb. 9:14, 26, 28; 10:10, 12, 14; Rom. 6:10; I Peter 3:18; John 16:11, 33; Phil. 2:9; Col. 2:14; I Cor. 15:4, 14; Mark 16:19; Luke 24:51; Acts 1:9; Matt. 26:64; Eph. 1:20; Col. 3:1; Heb. 1:13; 10:12; 12:2; Acts 2:1"]
+          "References": ["Matt. 1:18; Luke 1:35; Luke 2:7; Matt. 20:28; Matt. 26:28; Rom. 5:6; I Cor. 15:3; 1 Peter 2:24; Heb. 9:14, 26, 28; Heb. 10:10, 12, 14; Rom. 6:10; I Peter 3:18; John 16:11, 33; Phil. 2:9; Col. 2:14; I Cor. 15:4, 14; Mark 16:19; Luke 24:51; Acts 1:9; Matt. 26:64; Eph. 1:20; Col. 3:1; Heb. 1:13; Heb. 10:12; Heb. 12:2; Acts 2:1"]
         }
       ],
       "ProofsWithScripture": [
@@ -101,7 +101,7 @@
         },
         {
           "Id": 2,
-          "References": ["Matt. 1:18 ff.; Luke 1:35; 2:7. All the Evangelists attest it.  Matt. 20:28; 26e28; Rom. 5:6 ff.; I Cor. 15:3 f.; 1 Peter 2:24; Heb. 9:14 1.; 26. 28; 10:10, 12, 14; Rom. 6:10; I Peter 3:18: John 16:11, 33; Phil. 2:9 IL; Col. 2:14 1.; I Cor. 15:4 ff., 14; Mark 16:19; Luke 24:51: Acts 1:9 ff.; matt. 26:64; Eph. 1:20 ff.; Col. 3:1; Heb. 1:13; 10:12; 12:2; Acts 2:1 ff."]
+          "References": ["Matt. 1:18 ff.; Luke 1:35; Luke 2:7. All the Evangelists attest it.  Matt. 20:28; 26e28; Rom. 5:6 ff.; I Cor. 15:3 f.; 1 Peter 2:24; Heb. 9:14 1.; 26. 28; 10:10, 12, 14; Rom. 6:10; I Peter 3:18; John 16:11, 33; Phil. 2:9 IL; Col. 2:14 1.; I Cor. 15:4 ff., 14; Mark 16:19; Luke 24:51; Acts 1:9 ff.; matt. 26:64; Eph. 1:20 ff.; Col. 3:1; Heb. 1:13; Heb. 10:12; Heb. 12:2; Acts 2:1 ff."]
         }
       ]
     },
@@ -113,29 +113,29 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 16:18; Eph. 1:22; 5:25; John 3:29; II Cor. 11:2; Eph. 2:19; Heb. 12:22; John 1:29; Gal. 5:6"]
+          "References": ["Matt. 16:18; Eph. 1:22; Eph. 5:25; John 3:29; II Cor. 11:2; Eph. 2:19; Heb. 12:22; John 1:29; Gal. 5:6"]
         },
         {
           "Id": 2,
-          "References": ["Matt. 3:11; 28:19: Acts 2:41: 16:15, 33; Col. 2:12; Matt. 26:26; 14:22; Luke 22:19: I Cor. 11:23"]
+          "References": ["Matt. 3:11; Matt. 28:19; Acts 2:41; Acts 16:15, 33; Col. 2:12; Matt. 26:26; Matt. 14:22; Luke 22:19; I Cor. 11:23"]
         },
         {
           "Id": 3,
-          "References": ["Rom. 12:9; John 15:12, 17; I John 3:11, 14, 16, 23; 4:7, 20"]
+          "References": ["Rom. 12:9; John 15:12, 17; I John 3:11, 14, 16, 23; I John 4:7, 20"]
         }
       ],
       "ProofsWithScripture": [
         {
           "Id": 1,
-          "References": ["Matt. 16:18; Eph. 1:22; 5:25; John 3:29; II Cor. 11:2; Eph. 2:19; Heb. 12:22; John 1:29; Gal. 5:6"]
+          "References": ["Matt. 16:18; Eph. 1:22; Eph. 5:25; John 3:29; II Cor. 11:2; Eph. 2:19; Heb. 12:22; John 1:29; Gal. 5:6"]
         },
         {
           "Id": 2,
-          "References": ["Matt. 3:11; 28:19: Acts 2:41: 16:15, 33; Col. 2:12; Matt. 26:26; 14:22; Luke 22:19: I Cor. 11:23"]
+          "References": ["Matt. 3:11; Matt. 28:19; Acts 2:41; Acts 16:15, 33; Col. 2:12; Matt. 26:26; Matt. 14:22; Luke 22:19; I Cor. 11:23"]
         },
         {
           "Id": 3,
-          "References": ["Rom. 12:9; John 15:12, 17; I John 3:11, 14, 16, 23; 4:7, 20"]
+          "References": ["Rom. 12:9; John 15:12, 17; I John 3:11, 14, 16, 23; I John 4:7, 20"]
         }
       ]
     },
@@ -147,7 +147,7 @@
       "Proofs": [
         {
           "Id": 10,
-          "References": ["Luke 22:19; I Cor. 11:23; 10:16"]
+          "References": ["Luke 22:19; I Cor. 11:23; I Cor. 10:16"]
         },
         {
           "Id": 11,
@@ -155,7 +155,7 @@
         },
         {
           "Id": 12,
-          "References": ["John 11:25; Eph. 1:22; 4:15; 5:23; Col. 1:18"]
+          "References": ["John 11:25; Eph. 1:22; Eph. 4:15; Eph. 5:23; Col. 1:18"]
         },
         {
           "Id": 13,
@@ -163,7 +163,7 @@
         },
         {
           "Id": 14,
-          "References": ["Acts 1:9; 7:55; Col. 3:1; Heb. 1:3; 10:19"]
+          "References": ["Acts 1:9; Acts 7:55; Col. 3:1; Heb. 1:3; Heb. 10:19"]
         },
         {
           "Id": 15,
@@ -173,7 +173,7 @@
       "ProofsWithScripture": [
         {
           "Id": 10,
-          "References": ["Luke 22:19; I Cor. 11:23; 10:16"]
+          "References": ["Luke 22:19; I Cor. 11:23; I Cor. 10:16"]
         },
         {
           "Id": 11,
@@ -181,7 +181,7 @@
         },
         {
           "Id": 12,
-          "References": ["That is, the souls are satisfied, made strong and robust, contented and at peace, cheerful and a match for anything, just as the body is nourished by bodily food. A man becomes a spiritual member of the spiritual body of Christ. John 11:25 f.; Eph. 1:22 f.; 4:15; 5:23; Col. 1:18 f."]
+          "References": ["That is, the souls are satisfied, made strong and robust, contented and at peace, cheerful and a match for anything, just as the body is nourished by bodily food. A man becomes a spiritual member of the spiritual body of Christ. John 11:25 f.; Eph. 1:22 f.; Eph. 4:15; Eph. 5:23; Col. 1:18 f."]
         },
         {
           "Id": 13,
@@ -189,7 +189,7 @@
         },
         {
           "Id": 14,
-          "References": ["Acts 1:9; 7:55; Col. 3:1; Heb. 1:3; 10:19"]
+          "References": ["Acts 1:9; Acts 7:55; Col. 3:1; Heb. 1:3; Heb. 10:19"]
         },
         {
           "Id": 15,
@@ -249,13 +249,13 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 20:28; Mark 10:45; Luke 7:48, 50: John 3:15, 36; 5:24: 6:28 35, 40, 47; Rom. 3:21; 4; 10:4; Gal. 2:16; Rom. 3:27; Eph. 2:8, 13; I Cor. 1:1, 30; Rom. 8:32: Eph. 2:9; John 14:6"]
+          "References": ["Matt. 20:28; Mark 10:45; Luke 7:48, 50; John 3:15, 36; John 5:24; John 6:28 35, 40, 47; Rom. 3:21; 4; 10:4; Gal. 2:16; Rom. 3:27; Eph. 2:8, 13; I Cor. 1:1, 30; Rom. 8:32; Eph. 2:9; John 14:6"]
         }
       ],
       "ProofsWithScripture": [
         {
           "Id": 1,
-          "References": ["Matt. 20:28; Mark 10:45; Luke 7:48. 50: John 3:15 f., 36; 5:24: 6:28 35, 40, 47; Rom. 3:21 ff.; 4; 10:4 ff.; Gal. 2:16 ff.; Rom. 3:27 f.; Eph. 2:8 1.. 13 ff.; I Cor. 1:1, 30 f.; Rom. 8:32: Eph. 2:9 f.; John 14:6. Gratitude consists in recompensing blessings received. Now God cannot be recompensed at all since He does not lack anything. Hence we look to His demand, namely, faith and works of love. God demands faith for Himself and love for our fellowman."]
+          "References": ["Matt. 20:28; Mark 10:45; Luke 7:48, 50; John 3:15 f., 36; John 5:24; John 6:28 35, 40, 47; Rom. 3:21 ff.; 4; 10:4 ff.; Gal. 2:16 ff.; Rom. 3:27 f.; Eph. 2:8 1.. 13 ff.; I Cor. 1:1, 30 f.; Rom. 8:32; Eph. 2:9 f.; John 14:6. Gratitude consists in recompensing blessings received. Now God cannot be recompensed at all since He does not lack anything. Hence we look to His demand, namely, faith and works of love. God demands faith for Himself and love for our fellowman."]
         }
       ]
     },
@@ -271,7 +271,7 @@
         },
         {
           "Id": 2,
-          "References": ["Matt. 24:30; 25:31; II Tim. 4:1, 8; Rom. 2:5; II Cor. 5:10; John 5:25"]
+          "References": ["Matt. 24:30; Matt. 25:31; II Tim. 4:1, 8; Rom. 2:5; II Cor. 5:10; John 5:25"]
         }
       ],
       "ProofsWithScripture": [
@@ -281,7 +281,7 @@
         },
         {
           "Id": 2,
-          "References": ["Matt. 24:30; 25:31; II Tim. 4:1, 8; Rom. 2:5; II Cor. 5:10; John 5:25"]
+          "References": ["Matt. 24:30; Matt. 25:31; II Tim. 4:1, 8; Rom. 2:5; II Cor. 5:10; John 5:25"]
         }
       ]
     },

--- a/creeds/heidelberg_catechism.json
+++ b/creeds/heidelberg_catechism.json
@@ -36,7 +36,7 @@
         },
         {
           "Id": 4,
-          "References": ["I Pet. 1:18, 19; I John 1:7; 2:2"]
+          "References": ["I Pet. 1:18, 19; I John 1:7; I John 2:2"]
         },
         {
           "Id": 5,
@@ -44,7 +44,7 @@
         },
         {
           "Id": 6,
-          "References": ["John 6:39, 40; 10:27-30; II Thess. 3:3; I Pet. 1:5"]
+          "References": ["John 6:39, 40; John 10:27-30; II Thess. 3:3; I Pet. 1:5"]
         },
         {
           "Id": 7,
@@ -56,7 +56,7 @@
         },
         {
           "Id": 9,
-          "References": ["Rom. 8:15, 16; II Cor. 1:21, 22; 5:5; Eph. 1:13, 14"]
+          "References": ["Rom. 8:15, 16; II Cor. 1:21, 22; II Cor. 5:5; Eph. 1:13, 14"]
         },
         {
           "Id": 10,
@@ -76,7 +76,7 @@
         },
         {
           "Id": 2,
-          "References": ["John 17:3; Acts 4:12; 10:43"]
+          "References": ["John 17:3; Acts 4:12; Acts 10:43"]
         },
         {
           "Id": 3,
@@ -92,7 +92,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Rom. 3: 20;"]
+          "References": ["Rom. 3:20;"]
         }
       ]
     },
@@ -124,7 +124,7 @@
         },
         {
           "Id": 2,
-          "References": ["Gen. 6:5; 8:21; Jer. 17:9; Rom. 7:23; 8:7; Eph. 2:3; Tit. 3:3."]
+          "References": ["Gen. 6:5; Gen. 8:21; Jer. 17:9; Rom. 7:23; Rom. 8:7; Eph. 2:3; Tit. 3:3."]
         }
       ]
     },
@@ -184,7 +184,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Gen. 6:5; 8:21; Job 14:4; Is. 53:6"]
+          "References": ["Gen. 6:5; Gen. 8:21; Job 14:4; Is. 53:6"]
         },
         {
           "Id": 2,
@@ -224,7 +224,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ex. 34:7; Ps. 5:4-6; 7:10; Nah. 1:2; Rom. 1:18; 5:12; Eph. 5:6; Heb. 9:27"]
+          "References": ["Ex. 34:7; Ps. 5:4-6; Ps. 7:10; Nah. 1:2; Rom. 1:18; Rom. 5:12; Eph. 5:6; Heb. 9:27"]
         },
         {
           "Id": 2,
@@ -240,11 +240,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ex. 20:6; 34:6, 7; Ps. 103:8, 9"]
+          "References": ["Ex. 20:6; Ex. 34:6, 7; Ps. 103:8, 9"]
         },
         {
           "Id": 2,
-          "References": ["Ex. 20:5; 34:7; Deut. 7:9-11; Ps. 5:4-6; Heb. 10:30, 31"]
+          "References": ["Ex. 20:5; Ex. 34:7; Deut. 7:9-11; Ps. 5:4-6; Heb. 10:30, 31"]
         },
         {
           "Id": 3,
@@ -260,7 +260,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ex. 20:5; 23:7; Rom. 2:1-11"]
+          "References": ["Ex. 20:5; Ex. 23:7; Rom. 2:1-11"]
         },
         {
           "Id": 2,
@@ -312,7 +312,7 @@
         },
         {
           "Id": 3,
-          "References": ["Is. 7:14; 9:6; Jer. 23:6; John 1:1; Rom. 8:3, 4."]
+          "References": ["Is. 7:14; Is. 9:6; Jer. 23:6; John 1:1; Rom. 8:3, 4."]
         }
       ]
     },
@@ -324,7 +324,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Rom: 5:12, 15; I Cor. 15:21; Heb. 2:14-16"]
+          "References": ["Rom. 5:12, 15; I Cor. 15:21; Heb. 2:14-16"]
         },
         {
           "Id": 2,
@@ -360,7 +360,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 1:21-23; Luke 2:11; I Tim. 2:5; 3:16."]
+          "References": ["Matt. 1:21-23; Luke 2:11; I Tim. 2:5; I Tim. 3:16."]
         }
       ]
     },
@@ -376,7 +376,7 @@
         },
         {
           "Id": 2,
-          "References": ["Gen. 12:3; 22:18; 49:10"]
+          "References": ["Gen. 12:3; Gen. 22:18; Gen. 49:10"]
         },
         {
           "Id": 3,
@@ -400,7 +400,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 7:14; John 1:12; 3:16, 18, 36; Rom. 11:16-21."]
+          "References": ["Matt. 7:14; John 1:12; John 3:16, 18, 36; Rom. 11:16-21."]
         }
       ]
     },
@@ -416,7 +416,7 @@
         },
         {
           "Id": 2,
-          "References": ["Rom. 4:18-21; 5:1; 10:10; Heb. 4:16"]
+          "References": ["Rom. 4:18-21; Rom. 5:1; Rom. 10:10; Heb. 4:16"]
         },
         {
           "Id": 3,
@@ -432,7 +432,7 @@
         },
         {
           "Id": 6,
-          "References": ["Acts 16:14; Rom. 1:16; 10:17; I Cor. 1:21."]
+          "References": ["Acts 16:14; Rom. 1:16; Rom. 10:17; I Cor. 1:21."]
         }
       ]
     },
@@ -471,11 +471,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Deut. 6:4; Is. 44:6; 45:5; I Cor. 8:4, 6"]
+          "References": ["Deut. 6:4; Is. 44:6; Is. 45:5; I Cor. 8:4, 6"]
         },
         {
           "Id": 2,
-          "References": ["Gen. 1:2, 3; Is. 61:1; 63:8-10; Matt. 3:16, 17; 28:18, 19; Luke 4:18; John 14:26; 15:26; II Cor. 13:14; Gal. 4:6; Tit. 3:5, 6. God the Father and Our Creation"]
+          "References": ["Gen. 1:2, 3; Is. 61:1; Is. 63:8-10; Matt. 3:16, 17; Matt. 28:18, 19; Luke 4:18; John 14:26; John 15:26; II Cor. 13:14; Gal. 4:6; Tit. 3:5, 6. God the Father and Our Creation"]
         }
       ]
     },
@@ -487,11 +487,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Gen. 1 and 2; Ex. 20:11; Job 38 and 39; Ps. 33:6; Is. 44:24; Acts 4:24; 14:15"]
+          "References": ["Gen. 1 and 2; Ex. 20:11; Job 38 and 39; Ps. 33:6; Is. 44:24; Acts 4:24; Acts 14:15"]
         },
         {
           "Id": 2,
-          "References": ["Ps. 104:27-30; Matt. 6:30; 10:29; Eph. 1:11"]
+          "References": ["Ps. 104:27-30; Matt. 6:30; Matt. 10:29; Eph. 1:11"]
         },
         {
           "Id": 3,
@@ -511,7 +511,7 @@
         },
         {
           "Id": 7,
-          "References": ["Matt. 6:32, 33; 7:9-11."]
+          "References": ["Matt. 6:32, 33; Matt. 7:9-11."]
         }
       ]
     },
@@ -559,11 +559,11 @@
         },
         {
           "Id": 3,
-          "References": ["Ps. 55:22; Rom. 5:3-5; 8:38, 39"]
+          "References": ["Ps. 55:22; Rom. 5:3-5; Rom. 8:38, 39"]
         },
         {
           "Id": 4,
-          "References": ["Job 1:12; 2:6; Prov. 21:1; Acts 17:24-28."]
+          "References": ["Job 1:12; Job 2:6; Prov. 21:1; Acts 17:24-28."]
         }
       ]
     },
@@ -595,7 +595,7 @@
         },
         {
           "Id": 2,
-          "References": ["Col. 1:19, 20; 2:10; I John 1:7."]
+          "References": ["Col. 1:19, 20; Col. 2:10; I John 1:7."]
         }
       ]
     },
@@ -615,7 +615,7 @@
         },
         {
           "Id": 3,
-          "References": ["John 1:18; 15:15"]
+          "References": ["John 1:18; John 15:15"]
         },
         {
           "Id": 4,
@@ -623,7 +623,7 @@
         },
         {
           "Id": 5,
-          "References": ["Heb. 9:12; 10:11-14"]
+          "References": ["Heb. 9:12; Heb. 10:11-14"]
         },
         {
           "Id": 6,
@@ -679,7 +679,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["John 1:1-3, 14, 18; 3:16; Rom. 8:32; Heb. 1; I John 4:9"]
+          "References": ["John 1:1-3, 14, 18; John 3:16; Rom. 8:32; Heb. 1; I John 4:9"]
         },
         {
           "Id": 2,
@@ -715,7 +715,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["John 1:1; 10:30-36; Rom. 1:3; 9:5; Col. 1:15-17; I John 5:20"]
+          "References": ["John 1:1; John 10:30-36; Rom. 1:3; Rom. 9:5; Col. 1:15-17; I John 5:20"]
         },
         {
           "Id": 2,
@@ -735,7 +735,7 @@
         },
         {
           "Id": 6,
-          "References": ["Heb. 4:15; 7:26, 27."]
+          "References": ["Heb. 4:15; Heb. 7:26, 27."]
         }
       ]
     },
@@ -763,11 +763,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Is. 53; I Tim. 2:6; I Pet. 2:24; 3:18"]
+          "References": ["Is. 53; I Tim. 2:6; I Pet. 2:24; I Pet. 3:18"]
         },
         {
           "Id": 2,
-          "References": ["Rom. 3:25; I Cor. 5:7; Eph. 5:2; Heb. 10:14; I John 2:2; 4:10"]
+          "References": ["Rom. 3:25; I Cor. 5:7; Eph. 5:2; Heb. 10:14; I John 2:2; I John 4:10"]
         },
         {
           "Id": 3,
@@ -875,7 +875,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ps. 18:5, 6; 116:3; Matt. 26:36-46; 27:45, 46; Heb. 5:7-10"]
+          "References": ["Ps. 18:5, 6; Ps. 116:3; Matt. 26:36-46; Matt. 27:45, 46; Heb. 5:7-10"]
         },
         {
           "Id": 2,
@@ -915,7 +915,7 @@
         },
         {
           "Id": 2,
-          "References": ["Rom. 8:34; Heb. 4:14; 7:23-25; 9:24"]
+          "References": ["Rom. 8:34; Heb. 4:14; Heb. 7:23-25; Heb. 9:24"]
         },
         {
           "Id": 3,
@@ -936,11 +936,11 @@
         },
         {
           "Id": 2,
-          "References": ["Matt. 26:11; John 16:28; 17:11; Acts 3:19-21; Heb. 8:4"]
+          "References": ["Matt. 26:11; John 16:28; John 17:11; Acts 3:19-21; Heb. 8:4"]
         },
         {
           "Id": 3,
-          "References": ["Matt. 28:18-20; John 14:16-19; 16:13."]
+          "References": ["Matt. 28:18-20; John 14:16-19; John 16:13."]
         }
       ]
     },
@@ -956,7 +956,7 @@
         },
         {
           "Id": 2,
-          "References": ["John 1:14; 3:13; Col. 2:9."]
+          "References": ["John 1:14; John 3:13; Col. 2:9."]
         }
       ]
     },
@@ -972,11 +972,11 @@
         },
         {
           "Id": 2,
-          "References": ["John 14:2; 17:24; Eph. 2:4-6"]
+          "References": ["John 14:2; John 17:24; Eph. 2:4-6"]
         },
         {
           "Id": 3,
-          "References": ["John 14:16; Acts 2:33; II Cor. 1:21, 22; 5:5"]
+          "References": ["John 14:16; Acts 2:33; II Cor. 1:21, 22; II Cor. 5:5"]
         },
         {
           "Id": 4,
@@ -1012,7 +1012,7 @@
         },
         {
           "Id": 2,
-          "References": ["Ps. 2:9; 110:1, 2; John 10:27-30; Rev. 19:11-16."]
+          "References": ["Ps. 2:9; Ps. 110:1, 2; John 10:27-30; Rev. 19:11-16."]
         }
       ]
     },
@@ -1084,7 +1084,7 @@
         },
         {
           "Id": 5,
-          "References": ["Rom. 1:16; 10:14-17; Eph. 5:26"]
+          "References": ["Rom. 1:16; Rom. 10:14-17; Eph. 5:26"]
         },
         {
           "Id": 6,
@@ -1112,11 +1112,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Rom. 8:32; I Cor. 6:17; 12:4-7, 12, 13; I John 1:3"]
+          "References": ["Rom. 8:32; I Cor. 6:17; I Cor. 12:4-7, 12, 13; I John 1:3"]
         },
         {
           "Id": 2,
-          "References": ["Rom. 12:4-8; I Cor. 12:20-27; 13:1-7; Phil. 2:4-8."]
+          "References": ["Rom. 12:4-8; I Cor. 12:20-27; I Cor. 13:1-7; Phil. 2:4-8."]
         }
       ]
     },
@@ -1128,7 +1128,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ps. 103:3, 4, 10, 12; Mic. 7:18, 19; II Cor. 5:18-21; I John 1:7; 2:2"]
+          "References": ["Ps. 103:3, 4, 10, 12; Mic. 7:18, 19; II Cor. 5:18-21; I John 1:7; I John 2:2"]
         },
         {
           "Id": 2,
@@ -1136,7 +1136,7 @@
         },
         {
           "Id": 3,
-          "References": ["John 3:17, 18; 5:24; Rom. 8:1, 2."]
+          "References": ["John 3:17, 18; John 5:24; Rom. 8:1, 2."]
         }
       ]
     },
@@ -1148,7 +1148,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Luke 16:22; 23:43; Phil. 1:21-23"]
+          "References": ["Luke 16:22; Luke 23:43; Phil. 1:21-23"]
         },
         {
           "Id": 2,
@@ -1180,7 +1180,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Hab. 2:4; John 3:36; Rom. 1:17; 5:1, 2."]
+          "References": ["Hab. 2:4; John 3:36; Rom. 1:17; Rom. 5:1, 2."]
         }
       ]
     },
@@ -1232,7 +1232,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["I Cor. 1:30, 31; 2:2"]
+          "References": ["I Cor. 1:30, 31; I Cor. 2:2"]
         },
         {
           "Id": 2,
@@ -1368,7 +1368,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ez. 36:25; Zech. 13:1; Eph. 1:7; Heb. 12:24; I Pet. 1:2; Rev. 1:5; 7:14"]
+          "References": ["Ez. 36:25; Zech. 13:1; Eph. 1:7; Heb. 12:24; I Pet. 1:2; Rev. 1:5; Rev. 7:14"]
         },
         {
           "Id": 2,
@@ -1416,7 +1416,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["I Cor. 6:11; Rev. 1:5; 7:14"]
+          "References": ["I Cor. 6:11; Rev. 1:5; Rev. 7:14"]
         },
         {
           "Id": 2,
@@ -1436,7 +1436,7 @@
         },
         {
           "Id": 2,
-          "References": ["Ps. 22:11; Is. 44:1-3; Acts 2:38, 39; 16:31"]
+          "References": ["Ps. 22:11; Is. 44:1-3; Acts 2:38, 39; Acts 16:31"]
         },
         {
           "Id": 3,
@@ -1448,7 +1448,7 @@
         },
         {
           "Id": 5,
-          "References": ["Col. 2: 11-13."]
+          "References": ["Col. 2:11-13."]
         }
       ]
     },
@@ -1480,7 +1480,7 @@
         },
         {
           "Id": 3,
-          "References": ["Acts 1:9-11; 3:21; I Cor. 11:26; Col. 3:1"]
+          "References": ["Acts 1:9-11; Acts 3:21; I Cor. 11:26; Col. 3:1"]
         },
         {
           "Id": 4,
@@ -1488,7 +1488,7 @@
         },
         {
           "Id": 5,
-          "References": ["John 6:56-58; 15:1-6; Eph. 4:15, 16; I John 3:24."]
+          "References": ["John 6:56-58; John 15:1-6; Eph. 4:15, 16; I John 3:24."]
         }
       ]
     },
@@ -1524,7 +1524,7 @@
         },
         {
           "Id": 3,
-          "References": ["I Cor. 10:16, 17; 11:26-28"]
+          "References": ["I Cor. 10:16, 17; I Cor. 11:26-28"]
         },
         {
           "Id": 4,
@@ -1544,7 +1544,7 @@
         },
         {
           "Id": 2,
-          "References": ["I Cor. 10:16, 17; 11:26"]
+          "References": ["I Cor. 10:16, 17; I Cor. 11:26"]
         },
         {
           "Id": 3,
@@ -1560,15 +1560,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 26:28; John 19:30; Heb. 7:27; 9:12, 25, 26; 10:10-18"]
+          "References": ["Matt. 26:28; John 19:30; Heb. 7:27; Heb. 9:12, 25, 26; Heb. 10:10-18"]
         },
         {
           "Id": 2,
-          "References": ["I Cor. 6:17; 10:16, 17"]
+          "References": ["I Cor. 6:17; I Cor. 10:16, 17"]
         },
         {
           "Id": 3,
-          "References": ["Joh. 20:17; Acts 7:55, 56; Heb. 1:3; 8:1"]
+          "References": ["Joh. 20:17; Acts 7:55, 56; Heb. 1:3; Heb. 8:1"]
         },
         {
           "Id": 4,
@@ -1584,7 +1584,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["I Cor. 10:19-22; 11:26-32."]
+          "References": ["I Cor. 10:19-22; I Cor. 11:26-32."]
         }
       ]
     },
@@ -1620,7 +1620,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 16:19; John 3:31-36; 20:21-23."]
+          "References": ["Matt. 16:19; John 3:31-36; John 20:21-23."]
         }
       ]
     },
@@ -1648,7 +1648,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Rom. 6:13; 12:1, 2; I Pet. 2:5-10"]
+          "References": ["Rom. 6:13; Rom. 12:1, 2; I Pet. 2:5-10"]
         },
         {
           "Id": 2,
@@ -1660,7 +1660,7 @@
         },
         {
           "Id": 4,
-          "References": ["Matt. 5:14-16; Rom. 14:17-19; I Pet. 2:12; 3:1, 2."]
+          "References": ["Matt. 5:14-16; Rom. 14:17-19; I Pet. 2:12; I Pet. 3:1, 2."]
         }
       ]
     },
@@ -1708,7 +1708,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ps. 51:8, 12; Is. 57:15; Rom. 5:1; 14:17"]
+          "References": ["Ps. 51:8, 12; Is. 57:15; Rom. 5:1; Rom. 14:17"]
         },
         {
           "Id": 2,
@@ -1772,7 +1772,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["I Cor. 6:9, 10; 10:5-14; I John 5:21"]
+          "References": ["I Cor. 6:9, 10; I Cor. 10:5-14; I John 5:21"]
         },
         {
           "Id": 2,
@@ -1780,7 +1780,7 @@
         },
         {
           "Id": 3,
-          "References": ["Matt. 4:10; Rev. 19:10; 22:8, 9"]
+          "References": ["Matt. 4:10; Rev. 19:10; Rev. 22:8, 9"]
         },
         {
           "Id": 4,
@@ -1808,7 +1808,7 @@
         },
         {
           "Id": 10,
-          "References": ["Deut. 6:2; Ps. 111:10; Prov. 1:7; 9:10; Matt. 10:28; I Pet. 1:17"]
+          "References": ["Deut. 6:2; Ps. 111:10; Prov. 1:7; Prov. 9:10; Matt. 10:28; I Pet. 1:17"]
         },
         {
           "Id": 11,
@@ -1816,7 +1816,7 @@
         },
         {
           "Id": 12,
-          "References": ["Matt. 5:29, 30; 10:37-39; Acts 5:29."]
+          "References": ["Matt. 5:29, 30; Matt. 10:37-39; Acts 5:29."]
         }
       ]
     },
@@ -1940,11 +1940,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Deut. 6:13; 10:20; Jer. 4:1, 2; Heb. 6:16"]
+          "References": ["Deut. 6:13; Deut. 10:20; Jer. 4:1, 2; Heb. 6:16"]
         },
         {
           "Id": 2,
-          "References": ["Gen. 21:24; 31:53; Josh. 9:15; I Sam. 24:22; I Kings 1:29, 30; Rom. 1:9; II Cor. 1:23."]
+          "References": ["Gen. 21:24; Gen. 31:53; Josh. 9:15; I Sam. 24:22; I Kings 1:29, 30; Rom. 1:9; II Cor. 1:23."]
         }
       ]
     },
@@ -1960,7 +1960,7 @@
         },
         {
           "Id": 2,
-          "References": ["Matt. 5:34-37; 23:16-22; James 5:12."]
+          "References": ["Matt. 5:34-37; Matt. 23:16-22; James 5:12."]
         }
       ]
     },
@@ -1972,11 +1972,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Deut. 6:4-9; 20-25; I Cor. 9:13, 14; II Tim. 2:2; 3:13-17; Tit. 1:5"]
+          "References": ["Deut. 6:4-9; 20-25; I Cor. 9:13, 14; II Tim. 2:2; II Tim. 3:13-17; Tit. 1:5"]
         },
         {
           "Id": 2,
-          "References": ["Deut. 12:5-12; Ps. 40:9, 10; 68:26; Acts 2:42-47; Heb. 10:23-25"]
+          "References": ["Deut. 12:5-12; Ps. 40:9, 10; Ps. 68:26; Acts 2:42-47; Heb. 10:23-25"]
         },
         {
           "Id": 3,
@@ -2008,11 +2008,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ex. 21:17; Prov. 1:8; 4:1; Rom. 13:1, 2; Eph. 5:21, 22; 6:1-9; Col. 3:18-4:1"]
+          "References": ["Ex. 21:17; Prov. 1:8; Prov. 4:1; Rom. 13:1, 2; Eph. 5:21, 22; Eph. 6:1-9; Col. 3:18-4:1"]
         },
         {
           "Id": 2,
-          "References": ["Prov. 20:20; 23:22; I Pet.2:18"]
+          "References": ["Prov. 20:20; Prov. 23:22; I Pet.2:18"]
         },
         {
           "Id": 3,
@@ -2028,7 +2028,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Gen. 9:6; Lev. 19:17, 18; Matt. 5:21, 22; 26:52"]
+          "References": ["Gen. 9:6; Lev. 19:17, 18; Matt. 5:21, 22; Matt. 26:52"]
         },
         {
           "Id": 2,
@@ -2036,7 +2036,7 @@
         },
         {
           "Id": 3,
-          "References": ["Matt. 4:7; 26:52; Rom. 13:11-14"]
+          "References": ["Matt. 4:7; Matt. 26:52; Rom. 13:11-14"]
         },
         {
           "Id": 4,
@@ -2052,7 +2052,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Prov. 14:30; Rom. 1:29; 12:19; Gal. 5:19-21; James 1:20; I John 2:9-11"]
+          "References": ["Prov. 14:30; Rom. 1:29; Rom. 12:19; Gal. 5:19-21; James 1:20; I John 2:9-11"]
         },
         {
           "Id": 2,
@@ -2068,7 +2068,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 7:12; 22:39; Rom. 12:10"]
+          "References": ["Matt. 7:12; Matt. 22:39; Rom. 12:10"]
         },
         {
           "Id": 2,
@@ -2124,11 +2124,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ex. 22:1; I Cor. 5:9, 10; 6:9, 10"]
+          "References": ["Ex. 22:1; I Cor. 5:9, 10; I Cor. 6:9, 10"]
         },
         {
           "Id": 2,
-          "References": ["Deut. 25:13-16; Ps. 15:5; Prov. 11:1; 12:22; Ezek. 45:9-12; Luke 6:35"]
+          "References": ["Deut. 25:13-16; Ps. 15:5; Prov. 11:1; Prov. 12:22; Ezek. 45:9-12; Luke 6:35"]
         },
         {
           "Id": 3,
@@ -2140,7 +2140,7 @@
         },
         {
           "Id": 5,
-          "References": ["Prov. 21:20; 23:20, 21; Luke 16:10-13."]
+          "References": ["Prov. 21:20; Prov. 23:20, 21; Luke 16:10-13."]
         }
       ]
     },
@@ -2164,11 +2164,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ps. 15; Prov. 19:5, 9; 21:28; Matt. 7:1; Luke 6:37; Rom. 1:28-32"]
+          "References": ["Ps. 15; Prov. 19:5, 9; Prov. 21:28; Matt. 7:1; Luke 6:37; Rom. 1:28-32"]
         },
         {
           "Id": 2,
-          "References": ["Lev. 19:11, 12; Prov. 12:22; 13:5; John 8:44; Rev. 21:8"]
+          "References": ["Lev. 19:11, 12; Prov. 12:22; Prov. 13:5; John 8:44; Rev. 21:8"]
         },
         {
           "Id": 3,
@@ -2176,7 +2176,7 @@
         },
         {
           "Id": 4,
-          "References": ["I Pet. 3:8, 9; 4:8."]
+          "References": ["I Pet. 3:8, 9; I Pet. 4:8."]
         }
       ]
     },
@@ -2188,7 +2188,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ps. 19:7-14; 139:23, 24; Rom. 7:7, 8."]
+          "References": ["Ps. 19:7-14; Ps. 139:23, 24; Rom. 7:7, 8."]
         }
       ]
     },
@@ -2216,7 +2216,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ps. 32:5; Rom. 3:19-26; 7:7, 24, 25; I John 1:9"]
+          "References": ["Ps. 32:5; Rom. 3:19-26; Rom. 7:7, 24, 25; I John 1:9"]
         },
         {
           "Id": 2,
@@ -2232,7 +2232,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ps. 50:14, 15; 116:12-19; I Thess. 5:16-18"]
+          "References": ["Ps. 50:14, 15; Ps. 116:12-19; I Thess. 5:16-18"]
         },
         {
           "Id": 2,
@@ -2252,11 +2252,11 @@
         },
         {
           "Id": 2,
-          "References": ["II Chron. 7:14; 20:12; Ps. 2:11; 34:18; 62:8; Is. 66:2; Rev. 4"]
+          "References": ["II Chron. 7:14; II Chron. 20:12; Ps. 2:11; Ps. 34:18; Ps. 62:8; Is. 66:2; Rev. 4"]
         },
         {
           "Id": 3,
-          "References": ["Dan. 9:17-19; Matt. 7:8; John 14:13, 14; 16:23; Rom. 10:13; James 1:6."]
+          "References": ["Dan. 9:17-19; Matt. 7:8; John 14:13, 14; John 16:23; Rom. 10:13; James 1:6."]
         }
       ]
     },
@@ -2320,11 +2320,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Jer. 9:23, 24; 31: 33, 34; Matt. 16:17; John 17:3"]
+          "References": ["Jer. 9:23, 24; Jer. 31:33, 34; Matt. 16:17; John 17:3"]
         },
         {
           "Id": 2,
-          "References": ["Ex. 34:5-8; Ps. 145; Jer. 32:16-20; Luke 1:46-55, 68-75; Rom. 11: 33-36"]
+          "References": ["Ex. 34:5-8; Ps. 145; Jer. 32:16-20; Luke 1:46-55, 68-75; Rom. 11:33-36"]
         },
         {
           "Id": 3,
@@ -2340,11 +2340,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ps. 119:5, 105; 143:10; Matt. 6:33"]
+          "References": ["Ps. 119:5, 105; Ps. 143:10; Matt. 6:33"]
         },
         {
           "Id": 2,
-          "References": ["Ps. 51:18; 122:6-9; Matt. 16:18; Acts 2:42-47"]
+          "References": ["Ps. 51:18; Ps. 122:6-9; Matt. 16:18; Acts 2:42-47"]
         },
         {
           "Id": 3,
@@ -2352,7 +2352,7 @@
         },
         {
           "Id": 4,
-          "References": ["Rom. 8:22, 23; I Cor. 15:28; Rev. 22: 17, 20."]
+          "References": ["Rom. 8:22, 23; I Cor. 15:28; Rev. 22:17, 20."]
         }
       ]
     },
@@ -2364,7 +2364,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 7:21; 16:24-26; Luke 22:42; Rom. 12:1, 2; Tit. 2:11, 12"]
+          "References": ["Matt. 7:21; Matt. 16:24-26; Luke 22:42; Rom. 12:1, 2; Tit. 2:11, 12"]
         },
         {
           "Id": 2,
@@ -2384,15 +2384,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ps. 104:27-30; 145:15, 16; Matt. 6:25-34"]
+          "References": ["Ps. 104:27-30; Ps. 145:15, 16; Matt. 6:25-34"]
         },
         {
           "Id": 2,
-          "References": ["Acts 14:17; 17:25; James 1:17"]
+          "References": ["Acts 14:17; Acts 17:25; James 1:17"]
         },
         {
           "Id": 3,
-          "References": ["Deut. 8:3; Ps. 37:16; 127:1, 2; I Cor. 15:58"]
+          "References": ["Deut. 8:3; Ps. 37:16; Ps. 127:1, 2; I Cor. 15:58"]
         },
         {
           "Id": 4,
@@ -2408,11 +2408,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ps. 51:1-7; 143:2; Rom. 8:1; I John 2:1, 2"]
+          "References": ["Ps. 51:1-7; Ps. 143:2; Rom. 8:1; I John 2:1, 2"]
         },
         {
           "Id": 2,
-          "References": ["Matt. 6:14, 15; 18:21-35."]
+          "References": ["Matt. 6:14, 15; Matt. 18:21-35."]
         }
       ]
     },
@@ -2440,11 +2440,11 @@
         },
         {
           "Id": 5,
-          "References": ["Matt. 10:19, 20; 26:41; Mark 13:33; Rom. 5:3-5"]
+          "References": ["Matt. 10:19, 20; Matt. 26:41; Mark 13:33; Rom. 5:3-5"]
         },
         {
           "Id": 6,
-          "References": ["I Cor. 10:13; I Thess. 3:13; 5:23."]
+          "References": ["I Cor. 10:13; I Thess. 3:13; I Thess. 5:23."]
         }
       ]
     },

--- a/creeds/keachs_catechism.json
+++ b/creeds/keachs_catechism.json
@@ -24,7 +24,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Isaiah 44:6; Psalm 8:1; 97:9"]
+          "References": ["Isaiah 44:6; Psalm 8:1; Psalm 97:9"]
         }
       ]
     },
@@ -84,7 +84,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["John 5:39; Luke 16:29; Acts 8:28-30; 17:11"]
+          "References": ["John 5:39; Luke 16:29; Acts 8:28-30; Acts 17:11"]
         }
       ]
     },
@@ -264,7 +264,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ps. 51:5; Rom. 5:18,19: Is. 64:6"]
+          "References": ["Ps. 51:5; Rom. 5:18,19; Is. 64:6"]
         }
       ]
     },
@@ -276,7 +276,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Rom. 5:19; 3:10; Eph. 2:1; Is. 53:6; Ps. 51:5; Matt. 15:19"]
+          "References": ["Rom. 5:19; Rom. 3:10; Eph. 2:1; Is. 53:6; Ps. 51:5; Matt. 15:19"]
         }
       ]
     },
@@ -324,7 +324,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Heb. 2:14; Matt. 26:38; Luke 2:52; John 12:27; Luke 1:31,35; Heb. 4:15; 7:26"]
+          "References": ["Heb. 2:14; Matt. 26:38; Luke 2:52; John 12:27; Luke 1:31,35; Heb. 4:15; Heb. 7:26"]
         }
       ]
     },
@@ -348,7 +348,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["John 1:18; 14:26; 15:15"]
+          "References": ["John 1:18; John 14:26; John 15:15"]
         }
       ]
     },
@@ -360,7 +360,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["1 Peter 2:24; Heb. 9:28; Eph. 5:2; Heb. 2:17; 7:25; Rom. 8:34"]
+          "References": ["1 Peter 2:24; Heb. 9:28; Eph. 5:2; Heb. 2:17; Heb. 7:25; Rom. 8:34"]
         }
       ]
     },
@@ -420,7 +420,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Eph. 2:8; 3:17"]
+          "References": ["Eph. 2:8; Eph. 3:17"]
         }
       ]
     },
@@ -432,7 +432,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["2 Tim. 1:9; John 16:8-11; Acts 2:37; 26:18; Ezekiel 36:26; John 6:44,45; 1 Cor. 12:3"]
+          "References": ["2 Tim. 1:9; John 16:8-11; Acts 2:37; Acts 26:18; Ezekiel 36:26; John 6:44,45; 1 Cor. 12:3"]
         }
       ]
     },
@@ -492,7 +492,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Rom. 5:1-5; 14:17; Prov. 4:18; 1 Peter 1:5;1 John 5:13"]
+          "References": ["Rom. 5:1-5; Rom. 14:17; Prov. 4:18; 1 Peter 1:5;1 John 5:13"]
         }
       ]
     },
@@ -564,7 +564,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Rom. 2:14,15; 5:13,14"]
+          "References": ["Rom. 2:14,15; Rom. 5:13,14"]
         }
       ]
     },
@@ -816,7 +816,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ezekiel 22:26; 23:38; Jer. 17:21; Neh. 13:15,17; Acts 20:7"]
+          "References": ["Ezekiel 22:26; Ezekiel 23:38; Jer. 17:21; Neh. 13:15,17; Acts 20:7"]
         }
       ]
     },
@@ -828,7 +828,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Exodus 34:21; 31:16,17; Gen. 2:2,3"]
+          "References": ["Exodus 34:21; Exodus 31:16,17; Gen. 2:2,3"]
         }
       ]
     },
@@ -876,7 +876,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Eph. 6:2,3; Prov. 4:3-6; 6:20-22"]
+          "References": ["Eph. 6:2,3; Prov. 4:3-6; Prov. 6:20-22"]
         }
       ]
     },
@@ -912,7 +912,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Gen. 4:10,11; 9:6; Matt. 5:21-26"]
+          "References": ["Gen. 4:10,11; Gen. 9:6; Matt. 5:21-26"]
         }
       ]
     },
@@ -936,7 +936,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["1 Cor. 6:18; 7:2; 2 Tim. 2:22; Matt. 5:28; 1 Peter 3:2"]
+          "References": ["1 Cor. 6:18; 1 Cor. 7:2; 2 Tim. 2:22; Matt. 5:28; 1 Peter 3:2"]
         }
       ]
     },
@@ -972,7 +972,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Prov. 27:23; Lev. 25:35; Deut. 15:10; 22:14"]
+          "References": ["Prov. 27:23; Lev. 25:35; Deut. 15:10; Deut. 22:14"]
         }
       ]
     },
@@ -984,7 +984,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["1 Tim. 5:8; Prov. 28:19; 23:20,21; Eph. 4:28"]
+          "References": ["1 Tim. 5:8; Prov. 28:19; Prov. 23:20,21; Eph. 4:28"]
         }
       ]
     },
@@ -1080,7 +1080,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ps. 19:7-11; Rom. 3:20,31; 7:7; 12:2; Titus 2:12-14; Gal. 3:22,24; 1 Tim. 1:8"]
+          "References": ["Ps. 19:7-11; Rom. 3:20,31; Rom. 7:7; Rom. 12:2; Titus 2:12-14; Gal. 3:22,24; 1 Tim. 1:8"]
         }
       ]
     },
@@ -1116,7 +1116,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Acts 20:21; Acts 16:30,31; 17:30"]
+          "References": ["Acts 20:21; Acts 16:30,31; Acts 17:30"]
         }
       ]
     },
@@ -1140,7 +1140,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Acts 2:37; Joel 2:13; Jer. 31:18,19: 2 Cor.  7:10,11; Rom. 6:18"]
+          "References": ["Acts 2:37; Joel 2:13; Jer. 31:18,19; 2 Cor.  7:10,11; Rom. 6:18"]
         }
       ]
     },
@@ -1152,7 +1152,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Rom. 10:17; James 1:18; 1 Cor. 3:5; Acts 14:1; 2:41,42"]
+          "References": ["Rom. 10:17; James 1:18; 1 Cor. 3:5; Acts 14:1; Acts 2:41,42"]
         }
       ]
     },
@@ -1267,7 +1267,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Acts 2:42; 20:7; Acts 7:38; Eph. 4:11,12"]
+          "References": ["Acts 2:42; Acts 20:7; Acts 7:38; Eph. 4:11,12"]
         }
       ]
     },
@@ -1279,7 +1279,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Eph. 1:10; 1:22,23; John 10:16; 11:52"]
+          "References": ["Eph. 1:10; Eph. 1:22,23; John 10:16; John 11:52"]
         }
       ]
     },
@@ -1291,7 +1291,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["1 Cor. 11:23-26; 10:16"]
+          "References": ["1 Cor. 11:23-26; 1 Cor. 10:16"]
         }
       ]
     },
@@ -1315,7 +1315,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["1 John 5:14; 1 John 1:9; Phil. 4:6; Ps. 10:17; 145:19; John 14:13,14"]
+          "References": ["1 John 5:14; 1 John 1:9; Phil. 4:6; Ps. 10:17; Ps. 145:19; John 14:13,14"]
         }
       ]
     },
@@ -1387,7 +1387,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 6:11; Prov. 30:8,9; 1 Tim. 6:6-8; 4:4,5"]
+          "References": ["Matt. 6:11; Prov. 30:8,9; 1 Tim. 6:6-8; 1 Tim. 4:4,5"]
         }
       ]
     },
@@ -1411,7 +1411,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 6:13; 26:41; Ps. 19:13; 1 Cor. 10:13; John 17:15"]
+          "References": ["Matt. 6:13; Matt. 26:41; Ps. 19:13; 1 Cor. 10:13; John 17:15"]
         }
       ]
     },

--- a/creeds/puritan_catechism.json
+++ b/creeds/puritan_catechism.json
@@ -931,7 +931,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Eph 5:21,22; 6:1,5 Ro 13:1"]
+          "References": ["Eph 5:21,22; Eph 6:1,5 Ro 13:1"]
         },
         {
           "Id": 2,
@@ -1018,7 +1018,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["1Ti 5:8; Pr 28:19; 21:6"]
+          "References": ["1Ti 5:8; Pr 28:19; Pr 21:6"]
         },
         {
           "Id": 2,

--- a/creeds/westminster_larger_catechism.json
+++ b/creeds/westminster_larger_catechism.json
@@ -74,11 +74,11 @@
         },
         {
           "Id": 2,
-          "References": ["Psa. 12:6; 119:140"]
+          "References": ["Psa. 12:6; Psa. 119:140"]
         },
         {
           "Id": 3,
-          "References": ["Acts 10:43; 26:22"]
+          "References": ["Acts 10:43; Acts 26:22"]
         },
         {
           "Id": 4,
@@ -90,7 +90,7 @@
         },
         {
           "Id": 6,
-          "References": ["John 16:13-14; 20:31; 1 John 2:20, 27"]
+          "References": ["John 16:13-14; John 20:31; 1 John 2:20, 27"]
         }
       ]
     },
@@ -222,7 +222,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["I John 5:7; Matt. 3:16-17; 28:19; II Cor. 13:14; John 10:30"]
+          "References": ["I John 5:7; Matt. 3:16-17; Matt. 28:19; II Cor. 13:14; John 10:30"]
         }
       ]
     },
@@ -254,11 +254,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Isa. 6:3, 5, 8; John 12:41; Acts 5:3-4; 28:25; I John 5:20"]
+          "References": ["Isa. 6:3, 5, 8; John 12:41; Acts 5:3-4; Acts 28:25; I John 5:20"]
         },
         {
           "Id": 2,
-          "References": ["John 1:1; 2:24-25; Isa. 9:6; I Cor. 2:10-11"]
+          "References": ["John 1:1; John 2:24-25; Isa. 9:6; I Cor. 2:10-11"]
         },
         {
           "Id": 3,
@@ -278,7 +278,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Eph. 1:11; Rom. 9:14-15, 18; 11:33"]
+          "References": ["Eph. 1:11; Rom. 9:14-15, 18; Rom. 11:33"]
         },
         {
           "Id": 2,
@@ -502,7 +502,7 @@
         },
         {
           "Id": 4,
-          "References": ["Gen. 1:26-29; 3:8"]
+          "References": ["Gen. 1:26-29; Gen. 3:8"]
         },
         {
           "Id": 5,
@@ -558,7 +558,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Rom. 3:23; 5:12"]
+          "References": ["Rom. 3:23; Rom. 5:12"]
         }
       ]
     },
@@ -586,7 +586,7 @@
         },
         {
           "Id": 2,
-          "References": ["Rom. 3:10-19; 5:6; 8:7-8; Eph. 2:1-3; Gen. 6:5"]
+          "References": ["Rom. 3:10-19; Rom. 5:6; Rom. 8:7-8; Eph. 2:1-3; Gen. 6:5"]
         },
         {
           "Id": 3,
@@ -602,7 +602,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Psa. 51:5; Job 14:4; 15:14; John 3:6"]
+          "References": ["Psa. 51:5; Job 14:4; Job 15:14; John 3:6"]
         }
       ]
     },
@@ -734,7 +734,7 @@
         },
         {
           "Id": 3,
-          "References": ["John 1:12; 3:16"]
+          "References": ["John 1:12; John 3:16"]
         },
         {
           "Id": 4,
@@ -798,7 +798,7 @@
         },
         {
           "Id": 6,
-          "References": ["Heb. ch. 8-10; 11:13"]
+          "References": ["Heb. ch. 8-10; Heb. 11:13"]
         },
         {
           "Id": 7,
@@ -842,7 +842,7 @@
         },
         {
           "Id": 2,
-          "References": ["John 1:1, 14; 10:30; Phil. 2:6"]
+          "References": ["John 1:1, 14; John 10:30; Phil. 2:6"]
         },
         {
           "Id": 3,
@@ -870,7 +870,7 @@
         },
         {
           "Id": 3,
-          "References": ["Heb. 4:15; 7:26"]
+          "References": ["Heb. 4:15; Heb. 7:26"]
         }
       ]
     },
@@ -882,11 +882,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Acts. 2:24-25; Rom. 1:4; 4:25; Heb. 9:14"]
+          "References": ["Acts. 2:24-25; Rom. 1:4; Rom. 4:25; Heb. 9:14"]
         },
         {
           "Id": 2,
-          "References": ["Acts 20:28; Heb. 7:25-28; 9:14"]
+          "References": ["Acts 20:28; Heb. 7:25-28; Heb. 9:14"]
         },
         {
           "Id": 3,
@@ -910,7 +910,7 @@
         },
         {
           "Id": 8,
-          "References": ["Heb. 5:8-9; 9:11-15"]
+          "References": ["Heb. 5:8-9; Heb. 9:11-15"]
         }
       ]
     },
@@ -930,7 +930,7 @@
         },
         {
           "Id": 3,
-          "References": ["Heb. 2:14; 7:24-25"]
+          "References": ["Heb. 2:14; Heb. 7:24-25"]
         },
         {
           "Id": 4,
@@ -954,7 +954,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 1:21, 23; 3:17; Heb. 9:14"]
+          "References": ["Matt. 1:21, 23; Matt. 3:17; Heb. 9:14"]
         },
         {
           "Id": 2,
@@ -994,7 +994,7 @@
         },
         {
           "Id": 4,
-          "References": ["Heb. 4:14-15; 5:5-7"]
+          "References": ["Heb. 4:14-15; Heb. 5:5-7"]
         },
         {
           "Id": 5,
@@ -1078,7 +1078,7 @@
         },
         {
           "Id": 6,
-          "References": ["Rev. 2:10; 22:12"]
+          "References": ["Rev. 2:10; Rev. 22:12"]
         },
         {
           "Id": 7,
@@ -1154,7 +1154,7 @@
         },
         {
           "Id": 5,
-          "References": ["Heb. 2:17-18; 4:15; Isa. 52:13-14"]
+          "References": ["Heb. 2:17-18; Heb. 4:15; Isa. 52:13-14"]
         }
       ]
     },
@@ -1230,7 +1230,7 @@
         },
         {
           "Id": 4,
-          "References": ["Acts 1:11; 17:31"]
+          "References": ["Acts 1:11; Acts 17:31"]
         }
       ]
     },
@@ -1386,7 +1386,7 @@
         },
         {
           "Id": 3,
-          "References": ["John 3:16; 17:9, 20, 24"]
+          "References": ["John 3:16; John 17:9, 20, 24"]
         },
         {
           "Id": 4,
@@ -1478,7 +1478,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Eph. 1:13-14; John 6:37, 39; 10:15-16"]
+          "References": ["Eph. 1:13-14; John 6:37, 39; John 10:15-16"]
         },
         {
           "Id": 2,
@@ -1530,7 +1530,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["John 12:38-40; Rom. 9:6; 11:7; Matt. 7:21; 22:14"]
+          "References": ["John 12:38-40; Rom. 9:6; Rom. 11:7; Matt. 7:21; Matt. 22:14"]
         }
       ]
     },
@@ -1542,7 +1542,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["I Cor. 1:2; 12:13; Rom. 15:9-12; Rev. 7:9; Psa. 2:8; 22:27-31; 45:17; Matt. 28:19-20; Isa. 59:21"]
+          "References": ["I Cor. 1:2; I Cor. 12:13; Rom. 15:9-12; Rev. 7:9; Psa. 2:8; Psa. 22:27-31; Psa. 45:17; Matt. 28:19-20; Isa. 59:21"]
         },
         {
           "Id": 2,
@@ -1610,7 +1610,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Eph. 1:22; 2:6-8"]
+          "References": ["Eph. 1:22; Eph. 2:6-8"]
         },
         {
           "Id": 2,
@@ -1638,7 +1638,7 @@
         },
         {
           "Id": 3,
-          "References": ["II Cor. 5:20; 6:1-2; John 6:44; II Thess. 2:13-14"]
+          "References": ["II Cor. 5:20; II Cor. 6:1-2; John 6:44; II Thess. 2:13-14"]
         },
         {
           "Id": 4,
@@ -1646,7 +1646,7 @@
         },
         {
           "Id": 5,
-          "References": ["Ezek. 11:19; 36:26-27; John 6:45"]
+          "References": ["Ezek. 11:19; Ezek. 36:26-27; John 6:45"]
         },
         {
           "Id": 6,
@@ -1670,11 +1670,11 @@
         },
         {
           "Id": 3,
-          "References": ["Matt. 7:22; 13:20-21; Heb. 6:4-6"]
+          "References": ["Matt. 7:22; Matt. 13:20-21; Heb. 6:4-6"]
         },
         {
           "Id": 4,
-          "References": ["John 6:64-65; 12:38-40; Acts 18:25-27; Psa. 81:11-12"]
+          "References": ["John 6:64-65; John 12:38-40; Acts 18:25-27; Psa. 81:11-12"]
         }
       ]
     },
@@ -1706,7 +1706,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Rom. 3:22, 24-25; 4:5"]
+          "References": ["Rom. 3:22, 24-25; Rom. 4:5"]
         },
         {
           "Id": 2,
@@ -1718,7 +1718,7 @@
         },
         {
           "Id": 4,
-          "References": ["Rom. 4:6-8; 5:17-19"]
+          "References": ["Rom. 4:6-8; Rom. 5:17-19"]
         },
         {
           "Id": 5,
@@ -1738,7 +1738,7 @@
         },
         {
           "Id": 2,
-          "References": ["II Tim. 2:5-6; Heb. 7:22; 10:10; Matt. 20:28; Dan. 9:24, 26; Isa. 53:4-6, 10-12; Rom. 8:32; I Peter 1:18-19"]
+          "References": ["II Tim. 2:5-6; Heb. 7:22; Heb. 10:10; Matt. 20:28; Dan. 9:24, 26; Isa. 53:4-6, 10-12; Rom. 8:32; I Peter 1:18-19"]
         },
         {
           "Id": 3,
@@ -1778,7 +1778,7 @@
         },
         {
           "Id": 4,
-          "References": ["Acts 2:37; 4:12; 16:30; John 16:8-9; Rom. 5:6; Eph. 2:1"]
+          "References": ["Acts 2:37; Acts 4:12; Acts 16:30; John 16:8-9; Rom. 5:6; Eph. 2:1"]
         },
         {
           "Id": 5,
@@ -1786,7 +1786,7 @@
         },
         {
           "Id": 6,
-          "References": ["John 1:12; Acts 10:43; 16:31"]
+          "References": ["John 1:12; Acts 10:43; Acts 16:31"]
         },
         {
           "Id": 7,
@@ -1806,7 +1806,7 @@
         },
         {
           "Id": 2,
-          "References": ["Rom. 4:5; 10:10"]
+          "References": ["Rom. 4:5; Rom. 10:10"]
         },
         {
           "Id": 3,
@@ -1878,7 +1878,7 @@
         },
         {
           "Id": 6,
-          "References": ["Rom. 6:4; 6:14; Gal. 5:24"]
+          "References": ["Rom. 6:4; Rom. 6:14; Gal. 5:24"]
         }
       ]
     },
@@ -1938,7 +1938,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["I Cor. 1:30; 6:11"]
+          "References": ["I Cor. 1:30; I Cor. 6:11"]
         },
         {
           "Id": 2,
@@ -2018,7 +2018,7 @@
         },
         {
           "Id": 5,
-          "References": ["I John 2:27; 3:9"]
+          "References": ["I John 2:27; I John 3:9"]
         },
         {
           "Id": 6,
@@ -2042,7 +2042,7 @@
         },
         {
           "Id": 2,
-          "References": ["I Cor. 2:12; I John 3:14, 18-19, 21, 24; 4:13, 16; Heb. 6:11-12"]
+          "References": ["I Cor. 2:12; I John 3:14, 18-19, 21, 24; I John 4:13, 16; Heb. 6:11-12"]
         },
         {
           "Id": 3,
@@ -2070,7 +2070,7 @@
         },
         {
           "Id": 3,
-          "References": ["Psa. 22:1; 31:22; 51:8, 12; 77:1-12; Song of Sol. 5:2-3, 6"]
+          "References": ["Psa. 22:1; Psa. 31:22; Psa. 51:8, 12; Psa. 77:1-12; Song of Sol. 5:2-3, 6"]
         },
         {
           "Id": 4,
@@ -2114,7 +2114,7 @@
         },
         {
           "Id": 3,
-          "References": ["Rom. 5:1-2; 14:17"]
+          "References": ["Rom. 5:1-2; Rom. 14:17"]
         },
         {
           "Id": 4,
@@ -2330,7 +2330,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Gen. 1:26-27; 2:17; Rom. 2:14-15; 10:5"]
+          "References": ["Gen. 1:26-27; Gen. 2:17; Rom. 2:14-15; Rom. 10:5"]
         }
       ]
     },
@@ -2378,7 +2378,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Lev. 11:44-45; 20:7-8; Rom. 7:12"]
+          "References": ["Lev. 11:44-45; Lev. 20:7-8; Rom. 7:12"]
         },
         {
           "Id": 2,
@@ -2386,7 +2386,7 @@
         },
         {
           "Id": 3,
-          "References": ["Psa. 19:11-12; Rom. 3:20; 7:7"]
+          "References": ["Psa. 19:11-12; Rom. 3:20; Rom. 7:7"]
         },
         {
           "Id": 4,
@@ -2418,7 +2418,7 @@
         },
         {
           "Id": 3,
-          "References": ["Rom. 1:20; 2:15"]
+          "References": ["Rom. 1:20; Rom. 2:15"]
         },
         {
           "Id": 4,
@@ -2434,7 +2434,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Rom. 6:14; 7:4, 6; Gal. 4:4-5"]
+          "References": ["Rom. 6:14; Rom. 7:4, 6; Gal. 4:4-5"]
         },
         {
           "Id": 2,
@@ -2446,7 +2446,7 @@
         },
         {
           "Id": 4,
-          "References": ["Rom. 7:24-25; 8:3-4; Gal. 3:13-14"]
+          "References": ["Rom. 7:24-25; Rom. 8:3-4; Gal. 3:13-14"]
         },
         {
           "Id": 5,
@@ -2454,7 +2454,7 @@
         },
         {
           "Id": 6,
-          "References": ["Rom. 7:22; 12:2; Titus 2:11-14"]
+          "References": ["Rom. 7:22; Rom. 12:2; Titus 2:11-14"]
         }
       ]
     },
@@ -2486,7 +2486,7 @@
         },
         {
           "Id": 2,
-          "References": ["Rom. 7:14; Deut. 6:5; Matt. 5:21-22, 27-28, 33-34, 37-39, 43-44; 22:37-39"]
+          "References": ["Rom. 7:14; Deut. 6:5; Matt. 5:21-22, 27-28, 33-34, 37-39, 43-44; Matt. 22:37-39"]
         },
         {
           "Id": 3,
@@ -2494,7 +2494,7 @@
         },
         {
           "Id": 4,
-          "References": ["Isa. 58:13; Deut. 6:13; Matt. 4:9-10; 15:4-6"]
+          "References": ["Isa. 58:13; Deut. 6:13; Matt. 4:9-10; Matt. 15:4-6"]
         },
         {
           "Id": 5,
@@ -2506,11 +2506,11 @@
         },
         {
           "Id": 7,
-          "References": ["Jer. 18:7-8; Exod. 20:7; Psa. 15:1, 4-5; 24:4-5"]
+          "References": ["Jer. 18:7-8; Exod. 20:7; Psa. 15:1, 4-5; Psa. 24:4-5"]
         },
         {
           "Id": 8,
-          "References": ["Job. 13:7; 36:21; Rom. 3:8; Heb. 11:25"]
+          "References": ["Job. 13:7; Job. 36:21; Rom. 3:8; Heb. 11:25"]
         },
         {
           "Id": 9,
@@ -2522,7 +2522,7 @@
         },
         {
           "Id": 11,
-          "References": ["Matt. 5:21-22, 27-28; 15:4-6; Heb. 10:24-25; I Thess. 5:22-23; Gal. 5:26; Col. 3:21"]
+          "References": ["Matt. 5:21-22, 27-28; Matt. 15:4-6; Heb. 10:24-25; I Thess. 5:22-23; Gal. 5:26; Col. 3:21"]
         },
         {
           "Id": 12,
@@ -2621,7 +2621,7 @@
         },
         {
           "Id": 2,
-          "References": ["Psa. 29:2; 95:6-7; Matt. 4:10"]
+          "References": ["Psa. 29:2; Psa. 95:6-7; Matt. 4:10"]
         },
         {
           "Id": 3,
@@ -2953,7 +2953,7 @@
         },
         {
           "Id": 5,
-          "References": ["Matt. 16:19; 18:15-17; I Cor. ch. 5; 12:28"]
+          "References": ["Matt. 16:19; Matt. 18:15-17; I Cor. ch. 5; I Cor. 12:28"]
         },
         {
           "Id": 6,
@@ -3001,7 +3001,7 @@
         },
         {
           "Id": 4,
-          "References": ["I Kings 11:33; 12:33"]
+          "References": ["I Kings 11:33; I Kings 12:33"]
         },
         {
           "Id": 5,
@@ -3065,7 +3065,7 @@
         },
         {
           "Id": 20,
-          "References": ["I Sam. 13:11-12; 15:21"]
+          "References": ["I Sam. 13:11-12; I Sam. 15:21"]
         },
         {
           "Id": 21,
@@ -3145,7 +3145,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 6:9; Deut. 28:58; Psa. 29:2; 68:4; Rev. 15:3-4"]
+          "References": ["Matt. 6:9; Deut. 28:58; Psa. 29:2; Psa. 68:4; Rev. 15:3-4"]
         },
         {
           "Id": 2,
@@ -3237,7 +3237,7 @@
         },
         {
           "Id": 4,
-          "References": ["Mal. 1:6-7, 12; 3:14"]
+          "References": ["Mal. 1:6-7, 12; Mal. 3:14"]
         },
         {
           "Id": 5,
@@ -3265,7 +3265,7 @@
         },
         {
           "Id": 11,
-          "References": ["Zech. 5:4; 8:17"]
+          "References": ["Zech. 5:4; Zech. 8:17"]
         },
         {
           "Id": 12,
@@ -3273,7 +3273,7 @@
         },
         {
           "Id": 13,
-          "References": ["Jer. 5:7; 23:10"]
+          "References": ["Jer. 5:7; Jer. 23:10"]
         },
         {
           "Id": 14,
@@ -3281,7 +3281,7 @@
         },
         {
           "Id": 15,
-          "References": ["Esth. 3:7; 9:24; Psa. 22:18"]
+          "References": ["Esth. 3:7; Esth. 9:24; Psa. 22:18"]
         },
         {
           "Id": 16,
@@ -3301,11 +3301,11 @@
         },
         {
           "Id": 20,
-          "References": ["Rom. 3:5, 7; 6:1-2"]
+          "References": ["Rom. 3:5, 7; Rom. 6:1-2"]
         },
         {
           "Id": 21,
-          "References": ["Eccl. 8:11; 9:3; Psa. ch. 39"]
+          "References": ["Eccl. 8:11; Eccl. 9:3; Psa. ch. 39"]
         },
         {
           "Id": 22,
@@ -3325,7 +3325,7 @@
         },
         {
           "Id": 26,
-          "References": ["I Tim. 1:4, 6-7; 6:4-5, 20; II Tim. 2:14; Titus. 3:9"]
+          "References": ["I Tim. 1:4, 6-7; I Tim. 6:4-5, 20; II Tim. 2:14; Titus. 3:9"]
         },
         {
           "Id": 27,
@@ -3349,11 +3349,11 @@
         },
         {
           "Id": 32,
-          "References": ["Acts 4:18; 13:45-46, 50; 19:9; I Thess 2:16; Heb. 10:29"]
+          "References": ["Acts 4:18; Acts 13:45-46, 50; Acts 19:9; I Thess 2:16; Heb. 10:29"]
         },
         {
           "Id": 33,
-          "References": ["II Tim. 3:5; Matt. 6:1-2, 5, 16; 23:14"]
+          "References": ["II Tim. 3:5; Matt. 6:1-2, 5, 16; Matt. 23:14"]
         },
         {
           "Id": 34,
@@ -3401,7 +3401,7 @@
         },
         {
           "Id": 4,
-          "References": ["I Sam. 2:12, 17, 22, 24; 3:18"]
+          "References": ["I Sam. 2:12, 17, 22, 24; I Sam. 3:18"]
         }
       ]
     },
@@ -3453,11 +3453,11 @@
         },
         {
           "Id": 4,
-          "References": ["Isa. 58:13-14; 66:23; Luke 4:16; Acts 20:7; I Cor. 16:1-2; Psa. ch. 92; Lev. 23:3"]
+          "References": ["Isa. 58:13-14; Isa. 66:23; Luke 4:16; Acts 20:7; I Cor. 16:1-2; Psa. ch. 92; Lev. 23:3"]
         },
         {
           "Id": 5,
-          "References": ["Exod. 16:22, 25-26, 29; 20:8; Luke 23:54, 56; Neh. 13:19"]
+          "References": ["Exod. 16:22, 25-26, 29; Exod. 20:8; Luke 23:54, 56; Neh. 13:19"]
         }
       ]
     },
@@ -3469,7 +3469,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Exod. 20:10; 23:12; Josh. 24:15; Neh. 13:15, 17; Jer. 17:20-22"]
+          "References": ["Exod. 20:10; Exod. 23:12; Josh. 24:15; Neh. 13:15, 17; Jer. 17:20-22"]
         }
       ]
     },
@@ -3605,7 +3605,7 @@
         },
         {
           "Id": 3,
-          "References": ["Gen. 4:20-22; 45:8"]
+          "References": ["Gen. 4:20-22; Gen. 45:8"]
         },
         {
           "Id": 4,
@@ -3613,7 +3613,7 @@
         },
         {
           "Id": 5,
-          "References": ["II Kings 2:12; 13:14; Gal. 4:19"]
+          "References": ["II Kings 2:12; II Kings 13:14; Gal. 4:19"]
         },
         {
           "Id": 6,
@@ -3677,7 +3677,7 @@
         },
         {
           "Id": 6,
-          "References": ["Eph. 6:1-2, 5-7; I Peter 2:13-14; Rom. 13:1-5; Heb. 13:17; Prov. 4:3-4; 23:22; Exod. 18:19, 24"]
+          "References": ["Eph. 6:1-2, 5-7; I Peter 2:13-14; Rom. 13:1-5; Heb. 13:17; Prov. 4:3-4; Prov. 23:22; Exod. 18:19, 24"]
         },
         {
           "Id": 7,
@@ -3693,7 +3693,7 @@
         },
         {
           "Id": 10,
-          "References": ["Matt. 22:21; Rom. 13:6-7; I Tim. 5:17-18; Gal. 6:6; Gen. 45:11; 47:12"]
+          "References": ["Matt. 22:21; Rom. 13:6-7; I Tim. 5:17-18; Gal. 6:6; Gen. 45:11; Gen. 47:12"]
         },
         {
           "Id": 11,
@@ -3837,7 +3837,7 @@
         },
         {
           "Id": 3,
-          "References": ["John 5:44; 7:18"]
+          "References": ["John 5:44; John 7:18"]
         },
         {
           "Id": 4,
@@ -3881,7 +3881,7 @@
         },
         {
           "Id": 14,
-          "References": ["Gen. 9:21; I Kings 1:6; 12:13-16; I Sam. 2:29-31"]
+          "References": ["Gen. 9:21; I Kings 1:6; I Kings 12:13-16; I Sam. 2:29-31"]
         }
       ]
     },
@@ -3993,7 +3993,7 @@
         },
         {
           "Id": 7,
-          "References": ["I Sam. 24:2; 26:9-11; Gen. 37:21-22"]
+          "References": ["I Sam. 24:2; I Sam. 26:9-11; Gen. 37:21-22"]
         },
         {
           "Id": 8,
@@ -4037,7 +4037,7 @@
         },
         {
           "Id": 18,
-          "References": ["I Sam. 19:4-5; 22:13-14"]
+          "References": ["I Sam. 19:4-5; I Sam. 22:13-14"]
         },
         {
           "Id": 19,
@@ -4129,7 +4129,7 @@
         },
         {
           "Id": 14,
-          "References": ["Eccl. 2:22-23; 12:12"]
+          "References": ["Eccl. 2:22-23; Eccl. 12:12"]
         },
         {
           "Id": 15,
@@ -4137,7 +4137,7 @@
         },
         {
           "Id": 16,
-          "References": ["Prov. 12:18; 15:1"]
+          "References": ["Prov. 12:18; Prov. 15:1"]
         },
         {
           "Id": 17,
@@ -4253,7 +4253,7 @@
         },
         {
           "Id": 5,
-          "References": ["Matt. 5:28; 15:19; Col. 3:5"]
+          "References": ["Matt. 5:28; Matt. 15:19; Col. 3:5"]
         },
         {
           "Id": 6,
@@ -4309,7 +4309,7 @@
         },
         {
           "Id": 19,
-          "References": ["Eph. 5:4; Ezek. 23:14-16; Isa. 3:16; 23:15-17; Mark 6:22; Rom. 13:13; I Peter 4:3"]
+          "References": ["Eph. 5:4; Ezek. 23:14-16; Isa. 3:16; Isa. 23:15-17; Mark 6:22; Rom. 13:13; I Peter 4:3"]
         },
         {
           "Id": 20,
@@ -4337,7 +4337,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Psa. 15:2, 4; Zech. 7:4, 10; 8:16-17"]
+          "References": ["Psa. 15:2, 4; Zech. 7:4, 10; Zech. 8:16-17"]
         },
         {
           "Id": 2,
@@ -4361,7 +4361,7 @@
         },
         {
           "Id": 7,
-          "References": ["Prov. 27:23-27; Eccl. 2:24; 3:12-13; I Tim. 6:17-18; Isa. 38:1; Matt. 11:8"]
+          "References": ["Prov. 27:23-27; Eccl. 2:24; Eccl. 3:12-13; I Tim. 6:17-18; Isa. 38:1; Matt. 11:8"]
         },
         {
           "Id": 8,
@@ -4381,7 +4381,7 @@
         },
         {
           "Id": 12,
-          "References": ["Prov. 6:1-6; 11:15"]
+          "References": ["Prov. 6:1-6; Prov. 11:15"]
         },
         {
           "Id": 13,
@@ -4421,7 +4421,7 @@
         },
         {
           "Id": 7,
-          "References": ["Prov. 11:1; 20:10"]
+          "References": ["Prov. 11:1; Prov. 20:10"]
         },
         {
           "Id": 8,
@@ -4485,7 +4485,7 @@
         },
         {
           "Id": 23,
-          "References": ["Psa. 37:1, 7; 73:3"]
+          "References": ["Psa. 37:1, 7; Psa. 73:3"]
         },
         {
           "Id": 24,
@@ -4493,11 +4493,11 @@
         },
         {
           "Id": 25,
-          "References": ["Prov. 21:17; 23:20-21; 28:19"]
+          "References": ["Prov. 21:17; Prov. 23:20-21; Prov. 28:19"]
         },
         {
           "Id": 26,
-          "References": ["Eccl. 4:8; 6:2; I Tim. 5:8"]
+          "References": ["Eccl. 4:8; Eccl. 6:2; I Tim. 5:8"]
         }
       ]
     },
@@ -4569,7 +4569,7 @@
         },
         {
           "Id": 13,
-          "References": ["II Cor. 2:4; 12:21"]
+          "References": ["II Cor. 2:4; II Cor. 12:21"]
         },
         {
           "Id": 14,
@@ -4625,7 +4625,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["I Sam. 17:28; II Sam. 1:9-10, 15-16; 16:3"]
+          "References": ["I Sam. 17:28; II Sam. 1:9-10, 15-16; II Sam. 16:3"]
         },
         {
           "Id": 2,
@@ -4633,7 +4633,7 @@
         },
         {
           "Id": 3,
-          "References": ["Prov. 6:16, 19; 19:5"]
+          "References": ["Prov. 6:16, 19; Prov. 19:5"]
         },
         {
           "Id": 4,
@@ -4641,7 +4641,7 @@
         },
         {
           "Id": 5,
-          "References": ["Jer. 9:3, 5; Acts 24:2, 5; Psa. 3:1-4; 12:3-4"]
+          "References": ["Jer. 9:3, 5; Acts 24:2, 5; Psa. 3:1-4; Psa. 12:3-4"]
         },
         {
           "Id": 6,
@@ -4653,7 +4653,7 @@
         },
         {
           "Id": 8,
-          "References": ["Psa. 119:69; Luke 16:5-7; 19:8"]
+          "References": ["Psa. 119:69; Luke 16:5-7; Luke 19:8"]
         },
         {
           "Id": 9,
@@ -4757,7 +4757,7 @@
         },
         {
           "Id": 34,
-          "References": ["Prov. 28:13; 30:20; Gen. 3:12-13; 4:9; Jer. 2:35; II Kings 5:25"]
+          "References": ["Prov. 28:13; Prov. 30:20; Gen. 3:12-13; Gen. 4:9; Jer. 2:35; II Kings 5:25"]
         },
         {
           "Id": 35,
@@ -4809,7 +4809,7 @@
         },
         {
           "Id": 47,
-          "References": ["II Sam. 13:12-13; Prov. 5:8-9; 6:33"]
+          "References": ["II Sam. 13:12-13; Prov. 5:8-9; Prov. 6:33"]
         }
       ]
     },
@@ -4961,7 +4961,7 @@
         },
         {
           "Id": 14,
-          "References": ["Heb. 2:2-3; 12:25"]
+          "References": ["Heb. 2:2-3; Heb. 12:25"]
         },
         {
           "Id": 15,
@@ -5009,7 +5009,7 @@
         },
         {
           "Id": 26,
-          "References": ["Col. 3:5; I Tim. 6:10; Prov. 5:8-12; 6:32-33; Josh. 7:21"]
+          "References": ["Col. 3:5; I Tim. 6:10; Prov. 5:8-12; Prov. 6:32-33; Josh. 7:21"]
         },
         {
           "Id": 27,
@@ -5165,7 +5165,7 @@
         },
         {
           "Id": 3,
-          "References": ["Hab. 1:13; Lev. 10:3; 11:44-45"]
+          "References": ["Hab. 1:13; Lev. 10:3; Lev. 11:44-45"]
         },
         {
           "Id": 4,
@@ -5197,11 +5197,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Acts 16:30-31; 20:21; Matt. 3:7-8; Luke 13:3, 5; John 3:16, 18"]
+          "References": ["Acts 16:30-31; Acts 20:21; Matt. 3:7-8; Luke 13:3, 5; John 3:16, 18"]
         },
         {
           "Id": 2,
-          "References": ["Prov. 2:1-5; 8:33-36"]
+          "References": ["Prov. 2:1-5; Prov. 8:33-36"]
         }
       ]
     },
@@ -5233,7 +5233,7 @@
         },
         {
           "Id": 3,
-          "References": ["Acts 2:37, 41; 8:27-39"]
+          "References": ["Acts 2:37, 41; Acts 8:27-39"]
         },
         {
           "Id": 4,
@@ -5253,7 +5253,7 @@
         },
         {
           "Id": 8,
-          "References": ["Rom. 1:16; 10:13-17; 15:4; 16:25; I Thess. 3:2, 10-11, 13"]
+          "References": ["Rom. 1:16; Rom. 10:13-17; Rom. 15:4; Rom. 16:25; I Thess. 3:2, 10-11, 13"]
         }
       ]
     },
@@ -5265,7 +5265,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Deut. 31:9, 11-13; Neh. 8:2-3; 9:3-5"]
+          "References": ["Deut. 31:9, 11-13; Neh. 8:2-3; Neh. 9:3-5"]
         },
         {
           "Id": 2,
@@ -5341,7 +5341,7 @@
         },
         {
           "Id": 2,
-          "References": ["Jer. 14:15; Rom. 10:15; Heb. 5:4; I Cor. 12:28-29; I Tim. 3:10; 4:14; 5:22"]
+          "References": ["Jer. 14:15; Rom. 10:15; Heb. 5:4; I Cor. 12:28-29; I Tim. 3:10; I Tim. 4:14; I Tim. 5:22"]
         }
       ]
     },
@@ -5401,7 +5401,7 @@
         },
         {
           "Id": 13,
-          "References": ["II Cor. 2:17; 4:2"]
+          "References": ["II Cor. 2:17; II Cor. 4:2"]
         },
         {
           "Id": 14,
@@ -5489,7 +5489,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["I Peter 3:21; Acts 8:13, 23; I Cor. 3:6-7; 12:13"]
+          "References": ["I Peter 3:21; Acts 8:13, 23; I Cor. 3:6-7; I Cor. 12:13"]
         }
       ]
     },
@@ -5501,7 +5501,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Gen. 17:7, 10; Exod. ch. 12; Matt. 26:26-28; 28:19"]
+          "References": ["Gen. 17:7, 10; Exod. ch. 12; Matt. 26:26-28; Matt. 28:19"]
         },
         {
           "Id": 2,
@@ -5553,7 +5553,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 26:26-28; 28:19; I Cor. 11:20, 23"]
+          "References": ["Matt. 26:26-28; Matt. 28:19; I Cor. 11:20, 23"]
         }
       ]
     },
@@ -5605,11 +5605,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Acts 2:38; 8:36-37"]
+          "References": ["Acts 2:38; Acts 8:36-37"]
         },
         {
           "Id": 2,
-          "References": ["Gen. 17:7, 9; Gal. 3:9, 14; Col. 2:11-12; Acts 2:38-39; Rom. 4:11-12; 11:16; I Cor. 7:14; Matt 28:19; Luke 18:15-16"]
+          "References": ["Gen. 17:7, 9; Gal. 3:9, 14; Col. 2:11-12; Acts 2:38-39; Rom. 4:11-12; Rom. 11:16; I Cor. 7:14; Matt 28:19; Luke 18:15-16"]
         }
       ]
     },
@@ -5761,7 +5761,7 @@
         },
         {
           "Id": 8,
-          "References": ["I Cor. 5:8; 11:18, 20"]
+          "References": ["I Cor. 5:8; I Cor. 11:18, 20"]
         },
         {
           "Id": 9,
@@ -5801,11 +5801,11 @@
         },
         {
           "Id": 2,
-          "References": ["Isa. 54:7-10; Matt. 5:3-4; Psa. 31:22; 73:13, 22-23"]
+          "References": ["Isa. 54:7-10; Matt. 5:3-4; Psa. 31:22; Psa. 73:13, 22-23"]
         },
         {
           "Id": 3,
-          "References": ["Phil 3:8-9; Psa. 10:17; 42:1-2, 5, 11"]
+          "References": ["Phil 3:8-9; Psa. 10:17; Psa. 42:1-2, 5, 11"]
         },
         {
           "Id": 4,
@@ -5813,7 +5813,7 @@
         },
         {
           "Id": 5,
-          "References": ["Isa. 40:11, 29, 31; Matt. 11:28; 12:20; 26:28"]
+          "References": ["Isa. 40:11, 29, 31; Matt. 11:28; Matt. 12:20; Matt. 26:28"]
         },
         {
           "Id": 6,
@@ -5837,7 +5837,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["I Cor. ch. 5; 11:27-31; Matt. 7:6; Jude 1:23; I Tim. 5:22"]
+          "References": ["I Cor. ch. 5; I Cor. 11:27-31; Matt. 7:6; Jude 1:23; I Tim. 5:22"]
         },
         {
           "Id": 2,
@@ -5869,7 +5869,7 @@
         },
         {
           "Id": 5,
-          "References": ["I Cor. 10:3-5, 11, 14; 11:26"]
+          "References": ["I Cor. 10:3-5, 11, 14; I Cor. 11:26"]
         },
         {
           "Id": 6,
@@ -5945,7 +5945,7 @@
         },
         {
           "Id": 8,
-          "References": ["Psa. 42:5, 8; 43:3-5; 123:1-2"]
+          "References": ["Psa. 42:5, 8; Psa. 43:3-5; Psa. 123:1-2"]
         },
         {
           "Id": 9,
@@ -5977,7 +5977,7 @@
         },
         {
           "Id": 4,
-          "References": ["John 1:33; Matt. 28:19; I Cor. 4:1; 11:23; Heb. 5:4"]
+          "References": ["John 1:33; Matt. 28:19; I Cor. 4:1; I Cor. 11:23; Heb. 5:4"]
         },
         {
           "Id": 5,
@@ -6225,7 +6225,7 @@
         },
         {
           "Id": 2,
-          "References": ["Gen. 18:27; 32:10"]
+          "References": ["Gen. 18:27; Gen. 32:10"]
         },
         {
           "Id": 3,
@@ -6257,7 +6257,7 @@
         },
         {
           "Id": 10,
-          "References": ["Psa. 17:1; 145:18"]
+          "References": ["Psa. 17:1; Psa. 145:18"]
         },
         {
           "Id": 11,
@@ -6376,7 +6376,7 @@
         },
         {
           "Id": 6,
-          "References": ["II Thess. 3:1; Psa. 138:1-3; 147:19-20; II Cor. 2:14-15"]
+          "References": ["II Thess. 3:1; Psa. 138:1-3; Psa. 147:19-20; II Cor. 2:14-15"]
         },
         {
           "Id": 7,
@@ -6384,7 +6384,7 @@
         },
         {
           "Id": 8,
-          "References": ["Psa. 19:14; 103:1"]
+          "References": ["Psa. 19:14; Psa. 103:1"]
         },
         {
           "Id": 9,
@@ -6412,7 +6412,7 @@
         },
         {
           "Id": 15,
-          "References": ["II Chr. 20:6, 10-12; Psa. ch. 83; 140:4, 8"]
+          "References": ["II Chr. 20:6, 10-12; Psa. ch. 83; Psa. 140:4, 8"]
         }
       ]
     },
@@ -6460,7 +6460,7 @@
         },
         {
           "Id": 10,
-          "References": ["Acts 4:29-30; Eph. 6:18-20; Rom. 15:29-30, 32; II Thess. 1:11; 2:16-17"]
+          "References": ["Acts 4:29-30; Eph. 6:18-20; Rom. 15:29-30, 32; II Thess. 1:11; II Thess. 2:16-17"]
         },
         {
           "Id": 11,
@@ -6596,7 +6596,7 @@
         },
         {
           "Id": 9,
-          "References": ["Gen. 28:20; 43:12-14; Eph. 4:28; II Thess. 3:11-12; Phil. 4:6"]
+          "References": ["Gen. 28:20; Gen. 43:12-14; Eph. 4:28; II Thess. 3:11-12; Phil. 4:6"]
         },
         {
           "Id": 10,
@@ -6648,7 +6648,7 @@
         },
         {
           "Id": 8,
-          "References": ["Luke 11:4; Matt. 6:14-15; 18:35"]
+          "References": ["Luke 11:4; Matt. 6:14-15; Matt. 18:35"]
         }
       ]
     },
@@ -6688,7 +6688,7 @@
         },
         {
           "Id": 8,
-          "References": ["Matt. 26:69-72; Gal. 2:11-14; II Chr. 18:3; 19:2"]
+          "References": ["Matt. 26:69-72; Gal. 2:11-14; II Chr. 18:3; II Chr. 19:2"]
         },
         {
           "Id": 9,
@@ -6704,7 +6704,7 @@
         },
         {
           "Id": 12,
-          "References": ["Psa. 51:10; 119:133"]
+          "References": ["Psa. 51:10; Psa. 119:133"]
         },
         {
           "Id": 13,


### PR DESCRIPTION
#### Summary

When splitting the references by the semicolon (i.e., replacing `; ` with `", "`), I had found that some of the references would be missing the book. This change normalized the book name for references separated by a semicolon.

In addition, some usages of colon were either fixed with a semicolon, or corrected the space between chapter & verse.