### PR TITLE
Validate Bible references are in OSIS format

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="./metadata/feature_graphic.png">
   <a href="https://github.com/NonlinearFruit/Creeds.json/tree/master/creeds"><img src="https://img.shields.io/badge/documents-41-blue"></a>
   <a href="https://github.com/NonlinearFruit/Creeds.json/actions/workflows/DataValidation.yml"><img src="https://img.shields.io/github/actions/workflow/status/NonlinearFruit/Creeds.json/DataValidation.yml?label=tests&branch=master"></a>
-  <a href="https://github.com/NonlinearFruit/Creeds.json/tree/master/spec"><img src="https://img.shields.io/badge/test%20count-14715-yellowgreen"></a>
+  <a href="https://github.com/NonlinearFruit/Creeds.json/tree/master/spec"><img src="https://img.shields.io/badge/test%20count-19347-yellowgreen"></a>
 </p>
 
 This is a collection of historic creeds of the Christian faith. This repo focuses on the Reformed church.

--- a/creeds/1695_baptist_catechism.json
+++ b/creeds/1695_baptist_catechism.json
@@ -24,7 +24,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Isaiah 44:6", "Isaiah 48:12"]
+          "References": ["Isa.44.6", "Isa.48.12"]
         }
       ]
     },
@@ -36,11 +36,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Hebrews 11:6"]
+          "References": ["Heb.11.6"]
         },
         {
           "Id": 2,
-          "References": ["Psalms 14:1"]
+          "References": ["Ps.14.1"]
         }
       ]
     },
@@ -52,11 +52,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Rom. 1:19-20", "Psalms 19:1-3", "Acts 17:24"]
+          "References": ["Rom.1.19-Rom.1.20", "Ps.19.1-Ps.19.3", "Acts.17.24"]
         },
         {
           "Id": 2,
-          "References": ["1 Cor. 2:10", "2 Tim. 3:15-16"]
+          "References": ["1Cor.2.10", "2Tim.3.15-2Tim.3.16"]
         }
       ]
     },
@@ -68,7 +68,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["2 Tim. 3:16", "Eph. 2:20"]
+          "References": ["2Tim.3.16", "Eph.2.20"]
         }
       ]
     },
@@ -80,7 +80,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["John 5:39", "Deut. 17:18-19", "Rev. 1:3", "Acts 8:30"]
+          "References": ["John.5.39", "Deut.17.18-Deut.17.19", "Rev.1.3", "Acts.8.30"]
         }
       ]
     },
@@ -92,7 +92,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["2 Tim. 1:13", "2 Tim. 3:15-16"]
+          "References": ["2Tim.1.13", "2Tim.3.15-2Tim.3.16"]
         }
       ]
     },
@@ -104,39 +104,39 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["John 4:24"]
+          "References": ["John.4.24"]
         },
         {
           "Id": 2,
-          "References": ["Job 11:7-9"]
+          "References": ["Job.11.7-Job.11.9"]
         },
         {
           "Id": 3,
-          "References": ["Psal. 90:2"]
+          "References": ["Ps.90.2"]
         },
         {
           "Id": 4,
-          "References": ["Jam. 1:17"]
+          "References": ["Jas.1.17"]
         },
         {
           "Id": 5,
-          "References": ["Exod. 3:14"]
+          "References": ["Exod.3.14"]
         },
         {
           "Id": 6,
-          "References": ["Psal. 147:5"]
+          "References": ["Ps.147.5"]
         },
         {
           "Id": 7,
-          "References": ["Rev. 4:8"]
+          "References": ["Rev.4.8"]
         },
         {
           "Id": 8,
-          "References": ["Rev. 15:4"]
+          "References": ["Rev.15.4"]
         },
         {
           "Id": 9,
-          "References": ["Exod. 34:6-7"]
+          "References": ["Exod.34.6-Exod.34.7"]
         }
       ]
     },
@@ -148,7 +148,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Deut. 6:4", "Jer. 10:10"]
+          "References": ["Deut.6.4", "Jer.10.10"]
         }
       ]
     },
@@ -160,7 +160,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["1 John 5:7", "Mat. 28:19"]
+          "References": ["1John.5.7", "Matt.28.19"]
         }
       ]
     },
@@ -172,7 +172,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Eph. 1:4,11", "Rom. 9:22-23"]
+          "References": ["Eph.1.4,Eph.1.11", "Rom.9.22-Rom.9.23"]
         }
       ]
     },
@@ -191,7 +191,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Gen 1", "Heb. 11:3"]
+          "References": ["Gen.1", "Heb.11.3"]
         }
       ]
     },
@@ -203,7 +203,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Gen 1:26-28", "Col. 3:10", "Ephes. 4:24"]
+          "References": ["Gen.1.26-Gen.1.28", "Col.3.10", "Eph.4.24"]
         }
       ]
     },
@@ -215,19 +215,19 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Psal. 145:17"]
+          "References": ["Ps.145.17"]
         },
         {
           "Id": 2,
-          "References": ["Psal. 104:24", "Isa. 28:29"]
+          "References": ["Ps.104.24", "Isa.28.29"]
         },
         {
           "Id": 3,
-          "References": ["Heb. 1:3"]
+          "References": ["Heb.1.3"]
         },
         {
           "Id": 4,
-          "References": ["Psal. 103:19", "Mat. 10:29-31"]
+          "References": ["Ps.103.19", "Matt.10.29-Matt.10.31"]
         }
       ]
     },
@@ -239,7 +239,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Gal. 3:12", "Gen. 2:17"]
+          "References": ["Gal.3.12", "Gen.2.17"]
         }
       ]
     },
@@ -251,7 +251,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Gen. 3:6-8,13", "Eccles. 7:29"]
+          "References": ["Gen.3.6-Gen.3.8,Gen.3.13", "Eccl.7.29"]
         }
       ]
     },
@@ -263,7 +263,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["1 Joh. 3:4"]
+          "References": ["1John.3.4"]
         }
       ]
     },
@@ -275,7 +275,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Gen. 3:6,12"]
+          "References": ["Gen.3.6,Gen.3.12"]
         }
       ]
     },
@@ -287,7 +287,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Gen. 2:16-17", "Rom. 5:12", "1 Cor. 15:21-22"]
+          "References": ["Gen.2.16-Gen.2.17", "Rom.5.12", "1Cor.15.21-1Cor.15.22"]
         }
       ]
     },
@@ -299,7 +299,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Rom. 5:12"]
+          "References": ["Rom.5.12"]
         }
       ]
     },
@@ -311,7 +311,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Rom. 5:12-21", "Eph. 2:1-3", "Jam. 1:14-15", "Mat. 15:19"]
+          "References": ["Rom.5.12-Rom.5.21", "Eph.2.1-Eph.2.3", "Jas.1.14-Jas.1.15", "Matt.15.19"]
         }
       ]
     },
@@ -323,15 +323,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Gen. 3:8,10,24"]
+          "References": ["Gen.3.8,Gen.3.10,Gen.3.24"]
         },
         {
           "Id": 2,
-          "References": ["Eph 2:2-3", "Gal. 3:10"]
+          "References": ["Eph.2.2-Eph.2.3", "Gal.3.10"]
         },
         {
           "Id": 3,
-          "References": ["Lam. 3:39", "Rom. 6:23", "Mat. 25:41-46"]
+          "References": ["Lam.3.39", "Rom.6.23", "Matt.25.41-Matt.25.46"]
         }
       ]
     },
@@ -343,11 +343,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Eph. 1:4-5"]
+          "References": ["Eph.1.4-Eph.1.5"]
         },
         {
           "Id": 2,
-          "References": ["Rom. 3:20-22", "Gal. 3:21-22"]
+          "References": ["Rom.3.20-Rom.3.22", "Gal.3.21-Gal.3.22"]
         }
       ]
     },
@@ -359,15 +359,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["1 Tim. 2:5-6"]
+          "References": ["1Tim.2.5-1Tim.2.6"]
         },
         {
           "Id": 2,
-          "References": ["John 1:14", "Gal. 4:4"]
+          "References": ["John.1.14", "Gal.4.4"]
         },
         {
           "Id": 3,
-          "References": ["Rom. 9:5l Luke 1:23", "Col. 2:9", "Heb. 8:24-25"]
+          "References": ["Rom.9.5,Luke.1.23", "Col.2.9", "Heb.7.24-Heb.7.25"]
         }
       ]
     },
@@ -379,19 +379,19 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Heb. 2:14,16 & 10:5"]
+          "References": ["Heb.2.14,Heb.2.16,Heb.10.5"]
         },
         {
           "Id": 2,
-          "References": ["Mat. 26:38"]
+          "References": ["Matt.26.38"]
         },
         {
           "Id": 3,
-          "References": ["Luke 1:27,31,34,35,42", "Gal. 4:4"]
+          "References": ["Luke.1.27,Luke.1.31,Luke.1.34-Luke.1.35,Luke.1.42", "Gal.4.4"]
         },
         {
           "Id": 4,
-          "References": ["Heb. 4:15 & 7:26"]
+          "References": ["Heb.4.15,Heb.7.26"]
         }
       ]
     },
@@ -403,7 +403,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Acts 3.22", "Heb. 12:25 with 2 Cor. 13:3", "Heb. 5:5-7 & 7:25", "Psal. 2:6", "Isa. 9:6-7", "Mat. 21:5", "Ps. 2:8-11"]
+          "References": ["Acts.3.22", "Heb.12.25,2Cor.13.3", "Heb.5.5-Heb.5.7,Heb.7.25", "Ps.2.6", "Isa.9.6-Isa.9.7", "Matt.21.5", "Ps.2.8-Ps.2.11"]
         }
       ]
     },
@@ -415,7 +415,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["John 1:18", "1 Pet. 1:10-12", "John 15:15 & 20:31"]
+          "References": ["John.1.18", "1Pet.1.10-1Pet.1.12", "John.15.15,John.20.31"]
         }
       ]
     },
@@ -427,15 +427,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Heb. 9:14,28"]
+          "References": ["Heb.9.14,Heb.9.28"]
         },
         {
           "Id": 2,
-          "References": ["Heb. 2:17"]
+          "References": ["Heb.2.17"]
         },
         {
           "Id": 3,
-          "References": ["Heb. 7:24-25"]
+          "References": ["Heb.7.24-Heb.7.25"]
         }
       ]
     },
@@ -447,19 +447,19 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Acts 15:14-16"]
+          "References": ["Acts.15.14-Acts.15.16"]
         },
         {
           "Id": 2,
-          "References": ["Isa. 33:22"]
+          "References": ["Isa.33.22"]
         },
         {
           "Id": 3,
-          "References": ["Isa. 32:1,2"]
+          "References": ["Isa.32.1-Isa.32.2"]
         },
         {
           "Id": 4,
-          "References": ["1 Cor. 15:25", "Psal. 110"]
+          "References": ["1Cor.15.25", "Ps.110"]
         }
       ]
     },
@@ -471,31 +471,31 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Luke 2:7"]
+          "References": ["Luke.2.7"]
         },
         {
           "Id": 2,
-          "References": ["Gal. 4:4"]
+          "References": ["Gal.4.4"]
         },
         {
           "Id": 3,
-          "References": ["Heb. 12:2-3", "Isa. 53:2-3"]
+          "References": ["Heb.12.2-Heb.12.3", "Isa.53.2-Isa.53.3"]
         },
         {
           "Id": 4,
-          "References": ["Luke 22:44", "Mat. 27:46"]
+          "References": ["Luke.22.44", "Matt.27.46"]
         },
         {
           "Id": 5,
-          "References": ["Phil. 2:8"]
+          "References": ["Phil.2.8"]
         },
         {
           "Id": 6,
-          "References": ["1 Cor. 15:4"]
+          "References": ["1Cor.15.4"]
         },
         {
           "Id": 7,
-          "References": ["Act. 2:24-27,31"]
+          "References": ["Acts.2.24-Acts.2.27,Acts.2.31"]
         }
       ]
     },
@@ -507,19 +507,19 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["1 Cor. 15:4"]
+          "References": ["1Cor.15.4"]
         },
         {
           "Id": 2,
-          "References": ["Mark 16:19"]
+          "References": ["Mark.16.19"]
         },
         {
           "Id": 3,
-          "References": ["Ephes. 1:20"]
+          "References": ["Eph.1.20"]
         },
         {
           "Id": 4,
-          "References": ["Acts 1:11, 17:31"]
+          "References": ["Acts.1.11,Acts.17.31"]
         }
       ]
     },
@@ -531,11 +531,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["John 1:11-12"]
+          "References": ["John.1.11-John.1.12"]
         },
         {
           "Id": 2,
-          "References": ["Tit. 3:5-6"]
+          "References": ["Titus.3.5-Titus.3.6"]
         }
       ]
     },
@@ -547,11 +547,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Eph. 1:13-14", "John 6:37,39", "Ephes. 2:8"]
+          "References": ["Eph.1.13-Eph.1.14", "John.6.37,John.6.39", "Eph.2.8"]
         },
         {
           "Id": 2,
-          "References": ["Ephes. 3:17", "1 Cor. 1:9"]
+          "References": ["Eph.3.17", "1Cor.1.9"]
         }
       ]
     },
@@ -563,23 +563,23 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["2 Tim. 1:9", "2 Thes. 2.13-14"]
+          "References": ["2Tim.1.9", "2Thess.2.13-2Thess.2.14"]
         },
         {
           "Id": 2,
-          "References": ["Acts 2:37"]
+          "References": ["Acts.2.37"]
         },
         {
           "Id": 3,
-          "References": ["Acts 26:18"]
+          "References": ["Acts.26.18"]
         },
         {
           "Id": 4,
-          "References": ["Ezek. 36:26-27"]
+          "References": ["Ezek.36.26-Ezek.36.27"]
         },
         {
           "Id": 5,
-          "References": ["Joh. 6:44-45", "Phil. 2:13"]
+          "References": ["John.6.44-John.6.45", "Phil.2.13"]
         }
       ]
     },
@@ -591,15 +591,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Romans 8:30"]
+          "References": ["Rom.8.30"]
         },
         {
           "Id": 2,
-          "References": ["Ephesians 1:5"]
+          "References": ["Eph.1.5"]
         },
         {
           "Id": 3,
-          "References": ["1 Corinthians 1:30"]
+          "References": ["1Cor.1.30"]
         }
       ]
     },
@@ -611,19 +611,19 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Romans 5:24-25", "Romans 4:6-8"]
+          "References": ["Rom.3.24-Rom.3.25", "Rom.4.6-Rom.4.8"]
         },
         {
           "Id": 2,
-          "References": ["2 Corinthians 5:19,21"]
+          "References": ["2Cor.5.19,2Cor.5.21"]
         },
         {
           "Id": 3,
-          "References": ["Romans 5:17-19"]
+          "References": ["Rom.5.17-Rom.5.19"]
         },
         {
           "Id": 4,
-          "References": ["Galatians 2:16", "Philemon 3:9"]
+          "References": ["Gal.2.16", "Phil.3.9"]
         }
       ]
     },
@@ -635,11 +635,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["1 John 3:1"]
+          "References": ["1John.3.1"]
         },
         {
           "Id": 2,
-          "References": ["Romans 8:14"]
+          "References": ["Rom.8.14"]
         }
       ]
     },
@@ -651,15 +651,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["2 Thessalonians 2:13"]
+          "References": ["2Thess.2.13"]
         },
         {
           "Id": 2,
-          "References": ["Ephesians 4:23-24"]
+          "References": ["Eph.4.23-Eph.4.24"]
         },
         {
           "Id": 3,
-          "References": ["Romans 6:4,6"]
+          "References": ["Rom.6.4,Rom.6.6"]
         }
       ]
     },
@@ -671,19 +671,19 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Romans 5:1-2,5"]
+          "References": ["Rom.5.1-Rom.5.2,Rom.5.5"]
         },
         {
           "Id": 2,
-          "References": ["Romans 14:17"]
+          "References": ["Rom.14.17"]
         },
         {
           "Id": 3,
-          "References": ["Proverbs 4:18"]
+          "References": ["Prov.4.18"]
         },
         {
           "Id": 4,
-          "References": ["1 John 5:13", "1 Peter 1:5"]
+          "References": ["1John.5.13", "1Pet.1.5"]
         }
       ]
     },
@@ -695,23 +695,23 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Hebrews 12:23"]
+          "References": ["Heb.12.23"]
         },
         {
           "Id": 2,
-          "References": ["2 Corinthians 5:1,6,8", "Philemon 1:23", "Luke 23:43"]
+          "References": ["2Cor.5.1,2Cor.5.6,2Cor.5.8", "Phil.1.23", "Luke.23.43"]
         },
         {
           "Id": 3,
-          "References": ["1 Thessalonians 4:14"]
+          "References": ["1Thess.4.14"]
         },
         {
           "Id": 4,
-          "References": ["Isaiah 57:2"]
+          "References": ["Isa.57.2"]
         },
         {
           "Id": 5,
-          "References": ["Job 19:26-27"]
+          "References": ["Job.19.26-Job.19.27"]
         }
       ]
     },
@@ -723,19 +723,19 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["1 Corinthians 15:43"]
+          "References": ["1Cor.15.43"]
         },
         {
           "Id": 2,
-          "References": ["Matthew 25:23", "Matthew 10:32"]
+          "References": ["Matt.25.23", "Matt.10.32"]
         },
         {
           "Id": 3,
-          "References": ["1 John 3:2", "1 Corinthians 13:12"]
+          "References": ["1John.3.2", "1Cor.13.12"]
         },
         {
           "Id": 4,
-          "References": ["1 Thessalonians 4:17-18"]
+          "References": ["1Thess.4.17-1Thess.4.18"]
         }
       ]
     },
@@ -747,7 +747,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Luke 16:23-24", "Acts 1:25", "Jude 1:7", "1 Peter 3:19", "Psalms 49:14"]
+          "References": ["Luke.16.23-Luke.16.24", "Acts.1.25", "Jude.1.7", "1Pet.3.19", "Ps.49.14"]
         }
       ]
     },
@@ -759,7 +759,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["John 5:28-29", "Matthew 25:41,46", "2 Thessalonians 1:8-9"]
+          "References": ["John.5.28-John.5.29", "Matt.25.41,Matt.25.46", "2Thess.1.8-2Thess.1.9"]
         }
       ]
     },
@@ -771,7 +771,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Micah 6:8", "1 Samuel 15:22"]
+          "References": ["Mic.6.8", "1Sam.15.22"]
         }
       ]
     },
@@ -783,7 +783,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Romans 2:14-15", "Romans 10:5"]
+          "References": ["Rom.2.14-Rom.2.15", "Rom.10.5"]
         }
       ]
     },
@@ -795,7 +795,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Deuteronomy 10:4", "Matthew 19:17"]
+          "References": ["Deut.10.4", "Matt.19.17"]
         }
       ]
     },
@@ -807,7 +807,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matthew 22:37-40"]
+          "References": ["Matt.22.37-Matt.22.40"]
         }
       ]
     },
@@ -819,7 +819,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Exodus 20:2"]
+          "References": ["Exod.20.2"]
         }
       ]
     },
@@ -831,7 +831,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Luke 1:74-75", "1 Peter 1:15-19"]
+          "References": ["Luke.1.74-Luke.1.75", "1Pet.1.15-1Pet.1.19"]
         }
       ]
     },
@@ -843,7 +843,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Exodus 20:3"]
+          "References": ["Exod.20.3"]
         }
       ]
     },
@@ -855,11 +855,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["1 Chronicles 28:9", "Deuteronomy 26:17"]
+          "References": ["1Chr.28.9", "Deut.26.17"]
         },
         {
           "Id": 2,
-          "References": ["Matthew 4:10", "Psalms 29:2"]
+          "References": ["Matt.4.10", "Ps.29.2"]
         }
       ]
     },
@@ -871,19 +871,19 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Psalms 14:1"]
+          "References": ["Ps.14.1"]
         },
         {
           "Id": 2,
-          "References": ["Romans 1:21"]
+          "References": ["Rom.1.21"]
         },
         {
           "Id": 3,
-          "References": ["Psalms 81:10-11"]
+          "References": ["Ps.81.10-Ps.81.11"]
         },
         {
           "Id": 4,
-          "References": ["Romans 1:25-26"]
+          "References": ["Rom.1.25-Rom.1.26"]
         }
       ]
     },
@@ -895,7 +895,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ezekiel 8:5-18"]
+          "References": ["Ezek.8.5-Ezek.8.18"]
         }
       ]
     },
@@ -907,7 +907,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Exodus 20:4-6"]
+          "References": ["Exod.20.4-Exod.20.6"]
         }
       ]
     },
@@ -919,7 +919,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Deuteronomy 32:46", "Matthew 28:20", "Acts 2:42"]
+          "References": ["Deut.32.46", "Matt.28.20", "Acts.2.42"]
         }
       ]
     },
@@ -931,11 +931,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Deuteronomy 4:15-19", "Exodus 32:5,8"]
+          "References": ["Deut.4.15-Deut.4.19", "Exod.32.5,Exod.32.8"]
         },
         {
           "Id": 2,
-          "References": ["Deuteronomy 12:31-32"]
+          "References": ["Deut.12.31-Deut.12.32"]
         }
       ]
     },
@@ -947,15 +947,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Psalms 95:2-3,6"]
+          "References": ["Ps.95.2-Ps.95.3,Ps.95.6"]
         },
         {
           "Id": 2,
-          "References": ["Psalms 45:11"]
+          "References": ["Ps.45.11"]
         },
         {
           "Id": 3,
-          "References": ["Exodus 34:13-14"]
+          "References": ["Exod.34.13-Exod.34.14"]
         }
       ]
     },
@@ -967,7 +967,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Exodus 20:7"]
+          "References": ["Exod.20.7"]
         }
       ]
     },
@@ -979,27 +979,27 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matthew 6:9", "Deuteronomy 28:58"]
+          "References": ["Matt.6.9", "Deut.28.58"]
         },
         {
           "Id": 2,
-          "References": ["Psalms 68:4"]
+          "References": ["Ps.68.4"]
         },
         {
           "Id": 3,
-          "References": ["Revelation 15:3-4"]
+          "References": ["Rev.15.3-Rev.15.4"]
         },
         {
           "Id": 4,
-          "References": ["Malachi 1:11,14"]
+          "References": ["Mal.1.11,Mal.1.14"]
         },
         {
           "Id": 5,
-          "References": ["Psalms 138:1-2"]
+          "References": ["Ps.138.1-Ps.138.2"]
         },
         {
           "Id": 6,
-          "References": ["Job 35:24"]
+          "References": ["Job.36.24"]
         }
       ]
     },
@@ -1011,7 +1011,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Malachi 1:6-7,12", "Malachi 2:2", "Malachi 3:14"]
+          "References": ["Mal.1.6-Mal.1.7,Mal.1.12", "Mal.2.2", "Mal.3.14"]
         }
       ]
     },
@@ -1023,7 +1023,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["1 Samuel 2:12,17,22,24,29", "1 Samuel 3:13", "Deuteronomy 28:58-59"]
+          "References": ["1Sam.2.12,1Sam.2.17,1Sam.2.22,1Sam.2.24,1Sam.2.29", "1Sam.3.13", "Deut.28.58-Deut.28.59"]
         }
       ]
     },
@@ -1035,7 +1035,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Exodus 20:8-11"]
+          "References": ["Exod.20.8-Exod.20.11"]
         }
       ]
     },
@@ -1047,7 +1047,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Exodus 20:8-11", "Deuteronomy 5:12-14"]
+          "References": ["Exod.20.8-Exod.20.11", "Deut.5.12-Deut.5.14"]
         }
       ]
     },
@@ -1059,11 +1059,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Exodus 20:8-11", "Deuteronomy 5:12-14"]
+          "References": ["Exod.20.8-Exod.20.11", "Deut.5.12-Deut.5.14"]
         },
         {
           "Id": 2,
-          "References": ["Psalms 118:24", "Matthew 28:1", "Mark 2:27-28", "Mark 16:2", "Luke 24:1,30-36", "John 20:1,19-21,26", "Acts 1:3", "Acts 2:1-2", "Acts 20:7", "1 Corinthians 16:1-2", "Revelation 1:10"]
+          "References": ["Ps.118.24", "Matt.28.1", "Mark.2.27-Mark.2.28", "Mark.16.2", "Luke.24.1,Luke.24.30-Luke.24.36", "John.20.1,John.20.19-John.20.21,John.20.26", "Acts.1.3", "Acts.2.1-Acts.2.2", "Acts.20.7", "1Cor.16.1-1Cor.16.2", "Rev.1.10"]
         }
       ]
     },
@@ -1075,19 +1075,19 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Exodus 20:8,10"]
+          "References": ["Exod.20.8,Exod.20.10"]
         },
         {
           "Id": 2,
-          "References": ["Exodus 16:25-28", "Nehemiah 13:15-19,21-22"]
+          "References": ["Exod.16.25-Exod.16.28", "Neh.13.15-Neh.13.19,Neh.13.21-Neh.13.22"]
         },
         {
           "Id": 3,
-          "References": ["Luke 14:16", "Acts 20:7", "Psalms.92", "Isaiah 66:23"]
+          "References": ["Luke.14.16", "Acts.20.7", "Ps.92", "Isa.66.23"]
         },
         {
           "Id": 4,
-          "References": ["Matthew 12:1-13"]
+          "References": ["Matt.12.1-Matt.12.13"]
         }
       ]
     },
@@ -1099,19 +1099,19 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ezekiel 22:26", "Amos 8:5", "Malachi 1:13"]
+          "References": ["Ezek.22.26", "Amos.8.5", "Mal.1.13"]
         },
         {
           "Id": 2,
-          "References": ["Acts 20:7,9"]
+          "References": ["Acts.20.7,Acts.20.9"]
         },
         {
           "Id": 3,
-          "References": ["Ezekiel 23:38"]
+          "References": ["Ezek.23.38"]
         },
         {
           "Id": 4,
-          "References": ["Jeremiah 17:24-27", "Isaiah 58:13"]
+          "References": ["Jer.17.24-Jer.17.27", "Isa.58.13"]
         }
       ]
     },
@@ -1123,11 +1123,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Exodus 20:9"]
+          "References": ["Exod.20.9"]
         },
         {
           "Id": 2,
-          "References": ["Exodus 20:11"]
+          "References": ["Exod.20.11"]
         }
       ]
     },
@@ -1139,7 +1139,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Exodus 20:12"]
+          "References": ["Exod.20.12"]
         }
       ]
     },
@@ -1151,15 +1151,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ephesians 5:21"]
+          "References": ["Eph.5.21"]
         },
         {
           "Id": 2,
-          "References": ["1 Peter 2:17"]
+          "References": ["1Pet.2.17"]
         },
         {
           "Id": 3,
-          "References": ["Romans 12:10"]
+          "References": ["Rom.12.10"]
         }
       ]
     },
@@ -1171,7 +1171,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matthew 15:4-6", "Ezekiel 34:2-4", "Romans 13:8"]
+          "References": ["Matt.15.4-Matt.15.6", "Ezek.34.2-Ezek.34.4", "Rom.13.8"]
         }
       ]
     },
@@ -1183,7 +1183,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Deuteronomy 5:16", "Ephesians 6:2-3"]
+          "References": ["Deut.5.16", "Eph.6.2-Eph.6.3"]
         }
       ]
     },
@@ -1195,7 +1195,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Exodus 20:13"]
+          "References": ["Exod.20.13"]
         }
       ]
     },
@@ -1207,11 +1207,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ephesians 5:28-29"]
+          "References": ["Eph.5.28-Eph.5.29"]
         },
         {
           "Id": 2,
-          "References": ["1 Kings 18:4"]
+          "References": ["1Kgs.18.4"]
         }
       ]
     },
@@ -1223,7 +1223,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Acts 16:28", "Genesis 9:6"]
+          "References": ["Acts.16.28", "Gen.9.6"]
         }
       ]
     },
@@ -1235,7 +1235,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Exodus 20:14"]
+          "References": ["Exod.20.14"]
         }
       ]
     },
@@ -1247,7 +1247,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["1 Corinthians 7:2-3,5,34,36", "Colossians 4:6", "1 Peter 3:2"]
+          "References": ["1Cor.7.2-1Cor.7.3,1Cor.7.5,1Cor.7.34,1Cor.7.36", "Col.4.6", "1Pet.3.2"]
         }
       ]
     },
@@ -1259,7 +1259,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matthew 15:19", "Matthew 5:28", "Ephesians 5:3-4"]
+          "References": ["Matt.15.19", "Matt.5.28", "Eph.5.3-Eph.5.4"]
         }
       ]
     },
@@ -1271,7 +1271,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Exodus 20:15"]
+          "References": ["Exod.20.15"]
         }
       ]
     },
@@ -1283,7 +1283,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Genesis 30:30", "1 Timothy 5:8", "Leviticus 25:35", "Deuteronomy 22:1-5", "Exodus 23:4-5", "Genesis 47:14,20"]
+          "References": ["Gen.30.30", "1Tim.5.8", "Lev.25.35", "Deut.22.1-Deut.22.5", "Exod.23.4-Exod.23.5", "Gen.47.14,Gen.47.20"]
         }
       ]
     },
@@ -1295,7 +1295,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Proverbs 21:17", "Proverbs 23:20-21", "Proverbs 28:19", "Ephesians 4:28"]
+          "References": ["Prov.21.17", "Prov.23.20-Prov.23.21", "Prov.28.19", "Eph.4.28"]
         }
       ]
     },
@@ -1307,7 +1307,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Exodus 20:16"]
+          "References": ["Exod.20.16"]
         }
       ]
     },
@@ -1319,15 +1319,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Zechariah 8:16"]
+          "References": ["Zech.8.16"]
         },
         {
           "Id": 2,
-          "References": ["3 John 1:12"]
+          "References": ["3John.1.12"]
         },
         {
           "Id": 3,
-          "References": ["Proverbs 14:5,25"]
+          "References": ["Prov.14.5,Prov.14.25"]
         }
       ]
     },
@@ -1339,7 +1339,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["1 Samuel 17:28", "Leviticus 19:16", "Psalms 15:3"]
+          "References": ["1Sam.17.28", "Lev.19.16", "Ps.15.3"]
         }
       ]
     },
@@ -1351,7 +1351,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Exodus 20:17"]
+          "References": ["Exod.20.17"]
         }
       ]
     },
@@ -1363,11 +1363,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Hebrews 13:5", "1 Timothy 6:6"]
+          "References": ["Heb.13.5", "1Tim.6.6"]
         },
         {
           "Id": 2,
-          "References": ["Job 31:29", "Romans 12:15", "1 Timothy 1:5", "1 Corinthians 13:4-7"]
+          "References": ["Job.31.29", "Rom.12.15", "1Tim.1.5", "1Cor.13.4-1Cor.13.7"]
         }
       ]
     },
@@ -1379,15 +1379,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["1 Kings 21:4", "1 Esther 5:13", "1 Corinthians 10:10"]
+          "References": ["1Kgs.21.4", "Esth.5.13", "1Cor.10.10"]
         },
         {
           "Id": 2,
-          "References": ["Galatians 5:26", "James 3:14,16"]
+          "References": ["Gal.5.26", "Jas.3.14,Jas.3.16"]
         },
         {
           "Id": 3,
-          "References": ["Romans 7:7-8", "Romans 13:9"]
+          "References": ["Rom.7.7-Rom.7.8", "Rom.13.9"]
         }
       ]
     },
@@ -1399,11 +1399,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ecclesiastes 7:20", "1 John 1:8,10", "Galatians 5:17"]
+          "References": ["Eccl.7.20", "1John.1.8,1John.1.10", "Gal.5.17"]
         },
         {
           "Id": 2,
-          "References": ["Genesis 6:5", "Genesis 8:21", "Romans 3:9-21", "James 3:2-13"]
+          "References": ["Gen.6.5", "Gen.8.21", "Rom.3.9-Rom.3.21", "Jas.3.2-Jas.3.13"]
         }
       ]
     },
@@ -1415,7 +1415,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ezekiel 8:6,13,15", "1 John 5:16", "Psalms 78:17,32,56"]
+          "References": ["Ezek.8.6,Ezek.8.13,Ezek.8.15", "1John.5.16", "Ps.78.17,Ps.78.32,Ps.78.56"]
         }
       ]
     },
@@ -1427,7 +1427,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ephesians 5:6", "Galatians 3:10", "Lamentations 3:39", "Matthew 25:41", "Romans 6:23"]
+          "References": ["Eph.5.6", "Gal.3.10", "Lam.3.39", "Matt.25.41", "Rom.6.23"]
         }
       ]
     },
@@ -1439,11 +1439,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Acts 20:21"]
+          "References": ["Acts.20.21"]
         },
         {
           "Id": 2,
-          "References": ["Proverbs 2:1-6", "Proverbs 8:33-36", "Isaiah 55:2-3"]
+          "References": ["Prov.2.1-Prov.2.6", "Prov.8.33-Prov.8.36", "Isa.55.2-Isa.55.3"]
         }
       ]
     },
@@ -1455,11 +1455,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Hebrews 10:39"]
+          "References": ["Heb.10.39"]
         },
         {
           "Id": 2,
-          "References": ["John 1:12", "Isaiah 26:3-4", "Philemon 3:9", "Galatians 2:16"]
+          "References": ["John.1.12", "Isa.26.3-Isa.26.4", "Phil.3.9", "Gal.2.16"]
         }
       ]
     },
@@ -1471,23 +1471,23 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Acts 11:28"]
+          "References": ["Acts.11.28"]
         },
         {
           "Id": 2,
-          "References": ["Acts 2:37-38"]
+          "References": ["Acts.2.37-Acts.2.38"]
         },
         {
           "Id": 3,
-          "References": ["Joel 2:12", "Jeremiah 3:22"]
+          "References": ["Joel.2.12", "Jer.3.22"]
         },
         {
           "Id": 4,
-          "References": ["Jeremiah 31:18-19", "Ezekiel 36:31"]
+          "References": ["Jer.31.18-Jer.31.19", "Ezek.36.31"]
         },
         {
           "Id": 5,
-          "References": ["2 Corinthians 7:11", "Isaiah 1:16-17"]
+          "References": ["2Cor.7.11", "Isa.1.16-Isa.1.17"]
         }
       ]
     },
@@ -1499,7 +1499,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matthew 28:19-20", "Acts 2:42,46-47"]
+          "References": ["Matt.28.19-Matt.28.20", "Acts.2.42,Acts.2.46-Acts.2.47"]
         }
       ]
     },
@@ -1511,7 +1511,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Nehemiah 8:8", "1 Corinthians 14:24-25", "Acts 26:18", "Psalms 19:8", "Acts 20:32", "Romans 15:4", "1 Timothy 3:15-17", "Romans 10:13-17", "Romans 1:16"]
+          "References": ["Neh.8.8", "1Cor.14.24-1Cor.14.25", "Acts.26.18", "Ps.19.8", "Acts.20.32", "Rom.15.4", "1Tim.3.15-1Tim.3.16", "Rom.10.13-Rom.10.17", "Rom.1.16"]
         }
       ]
     },
@@ -1523,27 +1523,27 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Proverbs 8:34"]
+          "References": ["Prov.8.34"]
         },
         {
           "Id": 2,
-          "References": ["1 Peter 2:1-2"]
+          "References": ["1Pet.2.1-1Pet.2.2"]
         },
         {
           "Id": 3,
-          "References": ["Psalms 119:18"]
+          "References": ["Ps.119.18"]
         },
         {
           "Id": 4,
-          "References": ["Hebrews 4:2", "2 Thessalonians 2:10"]
+          "References": ["Heb.4.2", "2Thess.2.10"]
         },
         {
           "Id": 5,
-          "References": ["Psalms 119:11"]
+          "References": ["Ps.119.11"]
         },
         {
           "Id": 6,
-          "References": ["Luke 8:15", "James 1:25"]
+          "References": ["Luke.8.15", "Jas.1.25"]
         }
       ]
     },
@@ -1555,11 +1555,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["1 Peter 3:21", "Matthew 3:11", "1 Corinthians 3:6-7"]
+          "References": ["1Pet.3.21", "Matt.3.11", "1Cor.3.6-1Cor.3.7"]
         },
         {
           "Id": 2,
-          "References": ["1 Corinthians 12:13"]
+          "References": ["1Cor.12.13"]
         }
       ]
     },
@@ -1571,19 +1571,19 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matthew 28:19"]
+          "References": ["Matt.28.19"]
         },
         {
           "Id": 2,
-          "References": ["Romans 6:3-5", "Colossians 2:12", "Galatians 3:27"]
+          "References": ["Rom.6.3-Rom.6.5", "Col.2.12", "Gal.3.27"]
         },
         {
           "Id": 3,
-          "References": ["Mark 1:4", "Acts 2:38", "Acts 22:16"]
+          "References": ["Mark.1.4", "Acts.2.38", "Acts.22.16"]
         },
         {
           "Id": 4,
-          "References": ["Romans 6:3-4"]
+          "References": ["Rom.6.3-Rom.6.4"]
         }
       ]
     },
@@ -1595,7 +1595,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matthew 3:6", "Matthew 28:19", "Mark 16:16", "Acts 2:37-38", "Acts 8:36-38"]
+          "References": ["Matt.3.6", "Matt.28.19", "Mark.16.16", "Acts.2.37-Acts.2.38", "Acts.8.36-Acts.8.38"]
         }
       ]
     },
@@ -1615,7 +1615,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matthew 3:16", "John 3:23", "Matthew 28:19-20", "Acts 8:38", "Acts 10:48", "Romans 6:4", "Colossians 2:12"]
+          "References": ["Matt.3.16", "John.3.23", "Matt.28.19-Matt.28.20", "Acts.8.38", "Acts.10.48", "Rom.6.4", "Col.2.12"]
         }
       ]
     },
@@ -1627,7 +1627,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Acts 2:41-42", "Acts 5:13-14", "Act 9:26", "1 Peter 2:5", "Luke 1:6"]
+          "References": ["Acts.2.41-Acts.2.42", "Acts.5.13-Acts.5.14", "Acts.9.26", "1Pet.2.5", "Luke.1.6"]
         }
       ]
     },
@@ -1639,7 +1639,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matthew 26:26-28", "1 Corinthians 11:23-26", "1 Corinthians 19:16"]
+          "References": ["Matt.26.26-Matt.26.28", "1Cor.11.23-1Cor.11.26", "1Cor.10.16"]
         }
       ]
     },
@@ -1651,7 +1651,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Acts 2:41-42"]
+          "References": ["Acts.2.41-Acts.2.42"]
         }
       ]
     },
@@ -1663,27 +1663,27 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["1 Corinthians 11:28-29"]
+          "References": ["1Cor.11.28-1Cor.11.29"]
         },
         {
           "Id": 2,
-          "References": ["2 Corinthians 13:5"]
+          "References": ["2Cor.13.5"]
         },
         {
           "Id": 3,
-          "References": ["1 Corinthians 11:31"]
+          "References": ["1Cor.11.31"]
         },
         {
           "Id": 4,
-          "References": ["1 Corinthians 10:16-17"]
+          "References": ["1Cor.10.16-1Cor.10.17"]
         },
         {
           "Id": 5,
-          "References": ["1 Corinthians 5:7-8"]
+          "References": ["1Cor.5.7-1Cor.5.8"]
         },
         {
           "Id": 6,
-          "References": ["1 Corinthians 11:28-29"]
+          "References": ["1Cor.11.28-1Cor.11.29"]
         }
       ]
     },
@@ -1695,31 +1695,31 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Psalms 62:8"]
+          "References": ["Ps.62.8"]
         },
         {
           "Id": 2,
-          "References": ["Romans 6:26"]
+          "References": ["Rom.8.26"]
         },
         {
           "Id": 3,
-          "References": ["1 John 5:14"]
+          "References": ["1John.5.14"]
         },
         {
           "Id": 4,
-          "References": ["John 16:23"]
+          "References": ["John.16.23"]
         },
         {
           "Id": 5,
-          "References": ["Matthew 21:22", "James 1:6"]
+          "References": ["Matt.21.22", "Jas.1.6"]
         },
         {
           "Id": 6,
-          "References": ["Psalms 32:5-6", "Daniel 9:4"]
+          "References": ["Ps.32.5-Ps.32.6", "Dan.9.4"]
         },
         {
           "Id": 7,
-          "References": ["Philemon 4:6"]
+          "References": ["Phil.4.6"]
         }
       ]
     },
@@ -1731,11 +1731,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["1 John 5:14"]
+          "References": ["1John.5.14"]
         },
         {
           "Id": 2,
-          "References": ["Mark 6:9-13", "Luke 11:2-4"]
+          "References": ["Mark.6.9-Mark.6.13", "Luke.11.2-Luke.11.4"]
         }
       ]
     },
@@ -1747,15 +1747,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matthew 6:9"]
+          "References": ["Matt.6.9"]
         },
         {
           "Id": 2,
-          "References": ["Romans 8:15", "Luke 11:13"]
+          "References": ["Rom.8.15", "Luke.11.13"]
         },
         {
           "Id": 3,
-          "References": ["Acts 12:5", "1 Timothy 2:1-2"]
+          "References": ["Acts.12.5", "1Tim.2.1-1Tim.2.2"]
         }
       ]
     },
@@ -1767,15 +1767,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matthew 6:9"]
+          "References": ["Matt.6.9"]
         },
         {
           "Id": 2,
-          "References": ["Psalms 67:2-3"]
+          "References": ["Ps.67.2-Ps.67.3"]
         },
         {
           "Id": 3,
-          "References": ["Psalms.83"]
+          "References": ["Ps.83"]
         }
       ]
     },
@@ -1787,23 +1787,23 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matthew 6:10"]
+          "References": ["Matt.6.10"]
         },
         {
           "Id": 2,
-          "References": ["Psalms 68:1,18"]
+          "References": ["Ps.68.1,Ps.68.18"]
         },
         {
           "Id": 3,
-          "References": ["Revelation 12:10-11"]
+          "References": ["Rev.12.10-Rev.12.11"]
         },
         {
           "Id": 4,
-          "References": ["2 Thessalonians 3:1", "Romans 10:1", "John 17:19-20"]
+          "References": ["2Thess.3.1", "Rom.10.1", "John.17.19-John.17.20"]
         },
         {
           "Id": 5,
-          "References": ["Revelation 22:20"]
+          "References": ["Rev.22.20"]
         }
       ]
     },
@@ -1815,15 +1815,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matthew 6:10"]
+          "References": ["Matt.6.10"]
         },
         {
           "Id": 2,
-          "References": ["Psalms.67", "Psalms 119:36", "Matthew 26:39", "2 Samuel 15:25", "Job 1:21"]
+          "References": ["Ps.67", "Ps.119.36", "Matt.26.39", "2Sam.15.25", "Job.1.21"]
         },
         {
           "Id": 3,
-          "References": ["Psalms 103:20-21"]
+          "References": ["Ps.103.20-Ps.103.21"]
         }
       ]
     },
@@ -1835,11 +1835,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matthew 6:11"]
+          "References": ["Matt.6.11"]
         },
         {
           "Id": 2,
-          "References": ["Proverbs 30:8-9", "Genesis 28:20", "1 Timothy 4:4-5"]
+          "References": ["Prov.30.8-Prov.30.9", "Gen.28.20", "1Tim.4.4-1Tim.4.5"]
         }
       ]
     },
@@ -1851,15 +1851,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matthew 6:12"]
+          "References": ["Matt.6.12"]
         },
         {
           "Id": 2,
-          "References": ["Psalms 51:1-2,7,9", "Daniel 9:17-19"]
+          "References": ["Ps.51.1-Ps.51.2,Ps.51.7,Ps.51.9", "Dan.9.17-Dan.9.19"]
         },
         {
           "Id": 3,
-          "References": ["Luke 11:4", "Matthew 18:35"]
+          "References": ["Luke.11.4", "Matt.18.35"]
         }
       ]
     },
@@ -1871,15 +1871,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matthew 6:13"]
+          "References": ["Matt.6.13"]
         },
         {
           "Id": 2,
-          "References": ["Matthew 26:41"]
+          "References": ["Matt.26.41"]
         },
         {
           "Id": 3,
-          "References": ["2 Corinthians 12:8"]
+          "References": ["2Cor.12.8"]
         }
       ]
     },
@@ -1891,19 +1891,19 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matthew 6:13"]
+          "References": ["Matt.6.13"]
         },
         {
           "Id": 2,
-          "References": ["Daniel 9:4,7-9,16-19"]
+          "References": ["Dan.9.4,Dan.9.7-Dan.9.9,Dan.9.16-Dan.9.19"]
         },
         {
           "Id": 3,
-          "References": ["1 Chronicles 29:10-13"]
+          "References": ["1Chr.29.10-1Chr.29.13"]
         },
         {
           "Id": 4,
-          "References": ["1 Corinthians 14:16", "Revelation 22:20-21"]
+          "References": ["1Cor.14.16", "Rev.22.20-Rev.22.21"]
         }
       ]
     }

--- a/creeds/christ_hymn_of_colossians.json
+++ b/creeds/christ_hymn_of_colossians.json
@@ -19,7 +19,7 @@
     "Proofs": [
       {
         "Id": 1,
-        "References": ["Col. 1:15-19"]
+        "References": ["Col.1.15-Col.1.19"]
       }
     ]
   }

--- a/creeds/christ_hymn_of_philippians.json
+++ b/creeds/christ_hymn_of_philippians.json
@@ -19,7 +19,7 @@
     "Proofs": [
       {
         "Id": 1,
-        "References": ["Phil. 2:6-10"]
+        "References": ["Phil.2.6-Phil.2.10"]
       }
     ]
   }

--- a/creeds/christian_shema.json
+++ b/creeds/christian_shema.json
@@ -19,7 +19,7 @@
     "Proofs": [
       {
         "Id": 1,
-        "References": [ "1 Cor 8:6" ]
+        "References": [ "1Cor.8.6" ]
       }
     ]
   }

--- a/creeds/confession_of_peter.json
+++ b/creeds/confession_of_peter.json
@@ -18,7 +18,7 @@
       {
         "Id": 1,
         "References": [
-"Matt 16:16", "Mark 8:29", "Luke 9:20", "John 20:31", "1 John 5:1", "John 9:22", "John 11:27", "Mark 14:61"
+"Matt.16.16", "Mark.8.29", "Luke.9.20", "John.20.31", "1John.5.1", "John.9.22", "John.11.27", "Mark.14.61"
         ]
       }
     ]

--- a/creeds/first_confession_of_basel.json
+++ b/creeds/first_confession_of_basel.json
@@ -25,11 +25,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Gen. 1:1", "John 1:14", "I Chron. 29:11-12", "Acts 2:23"]
+          "References": ["Gen.1.1", "John.1.14", "1Chr.29.11-1Chr.29.12", "Acts.2.23"]
         },
         {
           "Id": 2,
-          "References": ["Rom. 8:28", "Rom. 9:6", "Rom. 11:5", "Eph. 1:4"]
+          "References": ["Rom.8.28", "Rom.9.6", "Rom.11.5", "Eph.1.4"]
         }
       ],
       "ProofsWithScripture": [
@@ -51,7 +51,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Gen. 1:26", "Eph. 4:21", "Gen. 8:6", "Gen. 5:3", "Rom. 5:12, 15", "I Cor.  15:21", "Eph. 2:1", "Gen. 6:5", "Gen. 8:21", "John 3:3", "Rom. 3:10, 23", "Ps. 143:2, 10", "Eph. 2:1"]
+          "References": ["Gen.1.26", "Eph.4.21", "Gen.8.6", "Gen.5.3", "Rom.5.12,Rom.5.15", "1Cor.15.21", "Eph.2.1", "Gen.6.5", "Gen.8.21", "John.3.3", "Rom.3.10,Rom.3.23", "Ps.143.2,Ps.143.10", "Eph.2.1"]
         }
       ],
       "ProofsWithScripture": [
@@ -69,7 +69,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Rom. 5:16", "Gen. 3:15", "Gen. 21:15", "Gen. 26:3-4, 24", "Gen. 28:13"]
+          "References": ["Rom.5.16", "Gen.3.15", "Gen.21.15", "Gen.26.3-Gen.26.4,Gen.26.24", "Gen.28.13"]
         }
       ],
       "ProofsWithScripture": [
@@ -87,11 +87,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Man. 1:20", "Luke 2:10", "John 1:14", "Phil. 2:6-7", "Rom. 6:8", "Rom. 8:15", "Heb. 2:10"]
+          "References": ["Matt.1.20", "Luke.2.10", "John.1.14", "Phil.2.6-Phil.2.7", "Rom.6.8", "Rom.8.15", "Heb.2.10"]
         },
         {
           "Id": 2,
-          "References": ["Matt. 1:18", "Luke 1:35", "Luke 2:7", "Matt. 20:28", "Matt. 26:28", "Rom. 5:6", "I Cor. 15:3", "1 Peter 2:24", "Heb. 9:14, 26, 28", "Heb. 10:10, 12, 14", "Rom. 6:10", "I Peter 3:18", "John 16:11, 33", "Phil. 2:9", "Col. 2:14", "I Cor. 15:4, 14", "Mark 16:19", "Luke 24:51", "Acts 1:9", "Matt. 26:64", "Eph. 1:20", "Col. 3:1", "Heb. 1:13", "Heb. 10:12", "Heb. 12:2", "Acts 2:1"]
+          "References": ["Matt.1.18", "Luke.1.35", "Luke.2.7", "Matt.20.28", "Matt.26.28", "Rom.5.6", "1Cor.15.3", "1Pet.2.24", "Heb.9.14,Heb.9.26,Heb.9.28", "Heb.10.10,Heb.10.12,Heb.10.14", "Rom.6.10", "1Pet.3.18", "John.16.11,John.16.33", "Phil.2.9", "Col.2.14", "1Cor.15.4,1Cor.15.14", "Mark.16.19", "Luke.24.51", "Acts.1.9", "Matt.26.64", "Eph.1.20", "Col.3.1", "Heb.1.13", "Heb.10.12", "Heb.12.2", "Acts.2.1"]
         }
       ],
       "ProofsWithScripture": [
@@ -113,15 +113,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 16:18", "Eph. 1:22", "Eph. 5:25", "John 3:29", "II Cor. 11:2", "Eph. 2:19", "Heb. 12:22", "John 1:29", "Gal. 5:6"]
+          "References": ["Matt.16.18", "Eph.1.22", "Eph.5.25", "John.3.29", "2Cor.11.2", "Eph.2.19", "Heb.12.22", "John.1.29", "Gal.5.6"]
         },
         {
           "Id": 2,
-          "References": ["Matt. 3:11", "Matt. 28:19", "Acts 2:41", "Acts 16:15, 33", "Col. 2:12", "Matt. 26:26", "Matt. 14:22", "Luke 22:19", "I Cor. 11:23"]
+          "References": ["Matt.3.11", "Matt.28.19", "Acts.2.41", "Acts.16.15,Acts.16.33", "Col.2.12", "Matt.26.26", "Matt.14.22", "Luke.22.19", "1Cor.11.23"]
         },
         {
           "Id": 3,
-          "References": ["Rom. 12:9", "John 15:12, 17", "I John 3:11, 14, 16, 23", "I John 4:7, 20"]
+          "References": ["Rom.12.9", "John.15.12,John.15.17", "1John.3.11,1John.3.14,1John.3.16,1John.3.23", "1John.4.7,1John.4.20"]
         }
       ],
       "ProofsWithScripture": [
@@ -147,15 +147,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Luke 22:19", "I Cor. 11:23", "I Cor. 10:16"]
+          "References": ["Luke.22.19", "1Cor.11.23", "1Cor.10.16"]
         },
         {
           "Id": 2,
-          "References": ["John 6:35"]
+          "References": ["John.6.35"]
         },
         {
           "Id": 3,
-          "References": ["John 11:25", "Eph. 1:22", "Eph. 4:15", "Eph. 5:23", "Col. 1:18"]
+          "References": ["John.11.25", "Eph.1.22", "Eph.4.15", "Eph.5.23", "Col.1.18"]
         },
         {
           "Id": 4,
@@ -163,11 +163,11 @@
         },
         {
           "Id": 5,
-          "References": ["Acts 1:9", "Acts 7:55", "Col. 3:1", "Heb. 1:3", "Heb. 10:19"]
+          "References": ["Acts.1.9", "Acts.7.55", "Col.3.1", "Heb.1.3", "Heb.10.19"]
         },
         {
           "Id": 6,
-          "References": ["Acts 3:21", "II Tim. 4:1"]
+          "References": ["Acts.3.21", "2Tim.4.1"]
         }
       ],
       "ProofsWithScripture": [
@@ -205,11 +205,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 18:15", "I Cor. 5:3", "II Thess. 3:6, 14", "I Tim. 1:19"]
+          "References": ["Matt.18.15", "1Cor.5.3", "2Thess.3.6,2Thess.3.14", "1Tim.1.19"]
         },
         {
           "Id": 2,
-          "References": ["11 Cor. 2:6", "I Tim. 1:20"]
+          "References": ["2Cor.2.6", "1Tim.1.20"]
         }
       ],
       "ProofsWithScripture": [
@@ -231,7 +231,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Rom. 13:1", "I Peter 2:13"]
+          "References": ["Rom.13.1", "1Pet.2.13"]
         }
       ],
       "ProofsWithScripture": [
@@ -249,7 +249,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 20:28", "Mark 10:45", "Luke 7:48, 50", "John 3:15, 36", "John 5:24", "John 6:28 35, 40, 47", "Rom. 3:21", "4", "10:4", "Gal. 2:16", "Rom. 3:27", "Eph. 2:8, 13", "I Cor. 1:1, 30", "Rom. 8:32", "Eph. 2:9", "John 14:6"]
+          "References": ["Matt.20.28", "Mark.10.45", "Luke.7.48,Luke.7.50", "John.3.15,John.3.36", "John.5.24", "John.6.28,John.6.35,John.6.40,John.6.47", "Rom.3.21", "Rom.4", "Rom.10.4", "Gal.2.16", "Rom.3.27", "Eph.2.8,Eph.2.13", "1Cor.1.1,1Cor.1.30", "Rom.8.32", "Eph.2.9", "John.14.6"]
         }
       ],
       "ProofsWithScripture": [
@@ -271,7 +271,7 @@
         },
         {
           "Id": 2,
-          "References": ["Matt. 24:30", "Matt. 25:31", "II Tim. 4:1, 8", "Rom. 2:5", "II Cor. 5:10", "John 5:25"]
+          "References": ["Matt.24.30", "Matt.25.31", "2Tim.4.1,2Tim.4.8", "Rom.2.5", "2Cor.5.10", "John.5.25"]
         }
       ],
       "ProofsWithScripture": [
@@ -293,7 +293,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 17:5", "Luke 9:35", "Deut.  18:18", "Acts 7:37"]
+          "References": ["Matt.17.5", "Luke.9.35", "Deut.18.18", "Acts.7.37"]
         },
         {
           "Id": 2,
@@ -301,7 +301,7 @@
         },
         {
           "Id": 3,
-          "References": ["Lev. 18:2", "Dent. 10:17", "I Tim. 1:4"]
+          "References": ["Lev.18.2", "Deut.10.17", "1Tim.1.4"]
         }
       ],
       "ProofsWithScripture": [

--- a/creeds/heidelberg_catechism.json
+++ b/creeds/heidelberg_catechism.json
@@ -24,43 +24,43 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["I Cor. 6:19, 2"]
+          "References": ["1Cor.6.19,1Cor.6.2"]
         },
         {
           "Id": 2,
-          "References": ["Rom. 14:7-9"]
+          "References": ["Rom.14.7-Rom.14.9"]
         },
         {
           "Id": 3,
-          "References": ["I Cor. 3:23", "Tit. 2:14"]
+          "References": ["1Cor.3.23", "Titus.2.14"]
         },
         {
           "Id": 4,
-          "References": ["I Pet. 1:18, 19", "I John 1:7", "I John 2:2"]
+          "References": ["1Pet.1.18-1Pet.1.19", "1John.1.7", "1John.2.2"]
         },
         {
           "Id": 5,
-          "References": ["John 8:34-36", "Heb. 2:14, 15", "I John 3:8"]
+          "References": ["John.8.34-John.8.36", "Heb.2.14-Heb.2.15", "1John.3.8"]
         },
         {
           "Id": 6,
-          "References": ["John 6:39, 40", "John 10:27-30", "II Thess. 3:3", "I Pet. 1:5"]
+          "References": ["John.6.39-John.6.40", "John.10.27-John.10.30", "2Thess.3.3", "1Pet.1.5"]
         },
         {
           "Id": 7,
-          "References": ["Matt. 10:29-31", "Luke 21:16-18"]
+          "References": ["Matt.10.29-Matt.10.31", "Luke.21.16-Luke.21.18"]
         },
         {
           "Id": 8,
-          "References": ["Rom. 8:28"]
+          "References": ["Rom.8.28"]
         },
         {
           "Id": 9,
-          "References": ["Rom. 8:15, 16", "II Cor. 1:21, 22", "II Cor. 5:5", "Eph. 1:13, 14"]
+          "References": ["Rom.8.15-Rom.8.16", "2Cor.1.21-2Cor.1.22", "2Cor.5.5", "Eph.1.13-Eph.1.14"]
         },
         {
           "Id": 10,
-          "References": ["Rom. 8:14."]
+          "References": ["Rom.8.14"]
         }
       ]
     },
@@ -72,15 +72,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Rom. 3:9, 10", "I John 1:10"]
+          "References": ["Rom.3.9-Rom.3.10", "1John.1.10"]
         },
         {
           "Id": 2,
-          "References": ["John 17:3", "Acts 4:12", "Acts 10:43"]
+          "References": ["John.17.3", "Acts.4.12", "Acts.10.43"]
         },
         {
           "Id": 3,
-          "References": ["Matt. 5:16", "Rom. 6:13", "Eph. 5:8-10", "I Pet. 2:9, 10."]
+          "References": ["Matt.5.16", "Rom.6.13", "Eph.5.8-Eph.5.10", "1Pet.2.9-1Pet.2.10"]
         }
       ]
     },
@@ -92,7 +92,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Rom. 3:20"]
+          "References": ["Rom.3.20"]
         }
       ]
     },
@@ -104,11 +104,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Deut. 6:5"]
+          "References": ["Deut.6.5"]
         },
         {
           "Id": 2,
-          "References": ["Lev. 19:18."]
+          "References": ["Lev.19.18"]
         }
       ]
     },
@@ -120,11 +120,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Rom. 3:10, 23", "I John 1:8, 10"]
+          "References": ["Rom.3.10,Rom.3.23", "1John.1.8,1John.1.10"]
         },
         {
           "Id": 2,
-          "References": ["Gen. 6:5", "Gen. 8:21", "Jer. 17:9", "Rom. 7:23", "Rom. 8:7", "Eph. 2:3", "Tit. 3:3."]
+          "References": ["Gen.6.5", "Gen.8.21", "Jer.17.9", "Rom.7.23", "Rom.8.7", "Eph.2.3", "Titus.3.3"]
         }
       ]
     },
@@ -136,23 +136,23 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Gen. 1:31"]
+          "References": ["Gen.1.31"]
         },
         {
           "Id": 2,
-          "References": ["Gen. 1:26, 27"]
+          "References": ["Gen.1.26-Gen.1.27"]
         },
         {
           "Id": 3,
-          "References": ["Eph. 4:24"]
+          "References": ["Eph.4.24"]
         },
         {
           "Id": 4,
-          "References": ["Col. 3:10"]
+          "References": ["Col.3.10"]
         },
         {
           "Id": 5,
-          "References": ["Ps. 8."]
+          "References": ["Ps.8"]
         }
       ]
     },
@@ -164,15 +164,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Gen. 3"]
+          "References": ["Gen.3"]
         },
         {
           "Id": 2,
-          "References": ["Rom. 5:12, 18, 19"]
+          "References": ["Rom.5.12,Rom.5.18-Rom.5.19"]
         },
         {
           "Id": 3,
-          "References": ["Ps. 51:5."]
+          "References": ["Ps.51.5"]
         }
       ]
     },
@@ -184,11 +184,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Gen. 6:5", "Gen. 8:21", "Job 14:4", "Is. 53:6"]
+          "References": ["Gen.6.5", "Gen.8.21", "Job.14.4", "Isa.53.6"]
         },
         {
           "Id": 2,
-          "References": ["John 3:3-5."]
+          "References": ["John.3.3-John.3.5"]
         }
       ]
     },
@@ -200,19 +200,19 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Gen. 1:31"]
+          "References": ["Gen.1.31"]
         },
         {
           "Id": 2,
-          "References": ["Gen. 3:13", "John 8:44", "I Tim. 2:13, 14"]
+          "References": ["Gen.3.13", "John.8.44", "1Tim.2.13-1Tim.2.14"]
         },
         {
           "Id": 3,
-          "References": ["Gen. 3:6"]
+          "References": ["Gen.3.6"]
         },
         {
           "Id": 4,
-          "References": ["Rom. 5:12, 18, 19."]
+          "References": ["Rom.5.12,Rom.5.18-Rom.5.19"]
         }
       ]
     },
@@ -224,11 +224,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ex. 34:7", "Ps. 5:4-6", "Ps. 7:10", "Nah. 1:2", "Rom. 1:18", "Rom. 5:12", "Eph. 5:6", "Heb. 9:27"]
+          "References": ["Exod.34.7", "Ps.5.4-Ps.5.6", "Ps.7.10", "Nah.1.2", "Rom.1.18", "Rom.5.12", "Eph.5.6", "Heb.9.27"]
         },
         {
           "Id": 2,
-          "References": ["Deut. 27:26."]
+          "References": ["Deut.27.26"]
         }
       ]
     },
@@ -240,15 +240,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ex. 20:6", "Ex. 34:6, 7", "Ps. 103:8, 9"]
+          "References": ["Exod.20.6", "Exod.34.6-Exod.34.7", "Ps.103.8-Ps.103.9"]
         },
         {
           "Id": 2,
-          "References": ["Ex. 20:5", "Ex. 34:7", "Deut. 7:9-11", "Ps. 5:4-6", "Heb. 10:30, 31"]
+          "References": ["Exod.20.5", "Exod.34.7", "Deut.7.9-Deut.7.11", "Ps.5.4-Ps.5.6", "Heb.10.30-Heb.10.31"]
         },
         {
           "Id": 3,
-          "References": ["Matt. 25:45,46."]
+          "References": ["Matt.25.45-Matt.25.46"]
         }
       ]
     },
@@ -260,11 +260,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ex. 20:5", "Ex. 23:7", "Rom. 2:1-11"]
+          "References": ["Exod.20.5", "Exod.23.7", "Rom.2.1-Rom.2.11"]
         },
         {
           "Id": 2,
-          "References": ["Is. 53:11", "Rom. 8:3, 4."]
+          "References": ["Isa.53.11", "Rom.8.3-Rom.8.4"]
         }
       ]
     },
@@ -276,7 +276,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ps. 130:3", "Matt. 6:12", "Rom. 2:4, 5."]
+          "References": ["Ps.130.3", "Matt.6.12", "Rom.2.4-Rom.2.5"]
         }
       ]
     },
@@ -288,11 +288,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ezek. 18:4, 20", "Heb. 2:14-18"]
+          "References": ["Ezek.18.4,Ezek.18.20", "Heb.2.14-Heb.2.18"]
         },
         {
           "Id": 2,
-          "References": ["Ps. 130:3", "Nah. 1:6."]
+          "References": ["Ps.130.3", "Nah.1.6"]
         }
       ]
     },
@@ -304,15 +304,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["I Cor. 15:21", "Heb. 2:17"]
+          "References": ["1Cor.15.21", "Heb.2.17"]
         },
         {
           "Id": 2,
-          "References": ["Is. 53:9", "II Cor. 5:21", "Heb. 7:26"]
+          "References": ["Isa.53.9", "2Cor.5.21", "Heb.7.26"]
         },
         {
           "Id": 3,
-          "References": ["Is. 7:14", "Is. 9:6", "Jer. 23:6", "John 1:1", "Rom. 8:3, 4."]
+          "References": ["Isa.7.14", "Isa.9.6", "Jer.23.6", "John.1.1", "Rom.8.3-Rom.8.4"]
         }
       ]
     },
@@ -324,11 +324,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Rom. 5:12, 15", "I Cor. 15:21", "Heb. 2:14-16"]
+          "References": ["Rom.5.12,Rom.5.15", "1Cor.15.21", "Heb.2.14-Heb.2.16"]
         },
         {
           "Id": 2,
-          "References": ["Heb. 7:26, 27", "I Pet. 3:18."]
+          "References": ["Heb.7.26-Heb.7.27", "1Pet.3.18"]
         }
       ]
     },
@@ -340,15 +340,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Is. 9:5"]
+          "References": ["Isa.9.5"]
         },
         {
           "Id": 2,
-          "References": ["Deut. 4:24", "Nah. 1:6", "Ps. 130:3"]
+          "References": ["Deut.4.24", "Nah.1.6", "Ps.130.3"]
         },
         {
           "Id": 3,
-          "References": ["Is. 53:5, 11", "John 3:16", "II Cor. 5:21."]
+          "References": ["Isa.53.5,Isa.53.11", "John.3.16", "2Cor.5.21"]
         }
       ]
     },
@@ -360,7 +360,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 1:21-23", "Luke 2:11", "I Tim. 2:5", "I Tim. 3:16."]
+          "References": ["Matt.1.21-Matt.1.23", "Luke.2.11", "1Tim.2.5", "1Tim.3.16"]
         }
       ]
     },
@@ -372,23 +372,23 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Gen. 3:15"]
+          "References": ["Gen.3.15"]
         },
         {
           "Id": 2,
-          "References": ["Gen. 12:3", "Gen. 22:18", "Gen. 49:10"]
+          "References": ["Gen.12.3", "Gen.22.18", "Gen.49.10"]
         },
         {
           "Id": 3,
-          "References": ["Is. 53", "Jer. 23:5, 6", "Mic. 7:18-20", "Acts 10:43", "Heb. 1:1"]
+          "References": ["Isa.53", "Jer.23.5-Jer.23.6", "Mic.7.18-Mic.7.20", "Acts.10.43", "Heb.1.1"]
         },
         {
           "Id": 4,
-          "References": ["Lev. 1:7", "John 5:46", "Heb. 10:1-10"]
+          "References": ["Lev.1.7", "John.5.46", "Heb.10.1-Heb.10.10"]
         },
         {
           "Id": 5,
-          "References": ["Rom. 10:4", "Gal. 4:4, 5", "Col. 2:17."]
+          "References": ["Rom.10.4", "Gal.4.4-Gal.4.5", "Col.2.17"]
         }
       ]
     },
@@ -400,7 +400,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 7:14", "John 1:12", "John 3:16, 18, 36", "Rom. 11:16-21."]
+          "References": ["Matt.7.14", "John.1.12", "John.3.16,John.3.18,John.3.36", "Rom.11.16-Rom.11.21"]
         }
       ]
     },
@@ -412,27 +412,27 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["John 17:3, 17", "Heb. 11:1-3", "James 2:19"]
+          "References": ["John.17.3,John.17.17", "Heb.11.1-Heb.11.3", "Jas.2.19"]
         },
         {
           "Id": 2,
-          "References": ["Rom. 4:18-21", "Rom. 5:1", "Rom. 10:10", "Heb. 4:16"]
+          "References": ["Rom.4.18-Rom.4.21", "Rom.5.1", "Rom.10.10", "Heb.4.16"]
         },
         {
           "Id": 3,
-          "References": ["Gal. 2:20"]
+          "References": ["Gal.2.20"]
         },
         {
           "Id": 4,
-          "References": ["Rom. 1:17", "Heb. 10:10"]
+          "References": ["Rom.1.17", "Heb.10.10"]
         },
         {
           "Id": 5,
-          "References": ["Rom.3:20-26", "Gal. 2:16", "Eph. 2:8-10"]
+          "References": ["Rom.3.20-Rom.3.26", "Gal.2.16", "Eph.2.8-Eph.2.10"]
         },
         {
           "Id": 6,
-          "References": ["Acts 16:14", "Rom. 1:16", "Rom. 10:17", "I Cor. 1:21."]
+          "References": ["Acts.16.14", "Rom.1.16", "Rom.10.17", "1Cor.1.21"]
         }
       ]
     },
@@ -444,7 +444,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 28:19", "John 20:30, 31."]
+          "References": ["Matt.28.19", "John.20.30-John.20.31"]
         }
       ]
     },
@@ -471,11 +471,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Deut. 6:4", "Is. 44:6", "Is. 45:5", "I Cor. 8:4, 6"]
+          "References": ["Deut.6.4", "Isa.44.6", "Isa.45.5", "1Cor.8.4,1Cor.8.6"]
         },
         {
           "Id": 2,
-          "References": ["Gen. 1:2, 3", "Is. 61:1", "Is. 63:8-10", "Matt. 3:16, 17", "Matt. 28:18, 19", "Luke 4:18", "John 14:26", "John 15:26", "II Cor. 13:14", "Gal. 4:6", "Tit. 3:5, 6. God the Father and Our Creation"]
+          "References": ["Gen.1.2-Gen.1.3", "Isa.61.1", "Isa.63.8-Isa.63.10", "Matt.3.16-Matt.3.17", "Matt.28.18-Matt.28.19", "Luke.4.18", "John.14.26", "John.15.26", "2Cor.13.14", "Gal.4.6", "Titus.3.5-Titus.3.6"]
         }
       ]
     },
@@ -487,31 +487,31 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Gen. 1 and 2", "Ex. 20:11", "Job 38 and 39", "Ps. 33:6", "Is. 44:24", "Acts 4:24", "Acts 14:15"]
+          "References": ["Gen.1-Gen.2", "Exod.20.11", "Job.38-Job.39", "Ps.33.6", "Isa.44.24", "Acts.4.24", "Acts.14.15"]
         },
         {
           "Id": 2,
-          "References": ["Ps. 104:27-30", "Matt. 6:30", "Matt. 10:29", "Eph. 1:11"]
+          "References": ["Ps.104.27-Ps.104.30", "Matt.6.30", "Matt.10.29", "Eph.1.11"]
         },
         {
           "Id": 3,
-          "References": ["John 1:12, 13", "Rom. 8:15, 16", "Gal. 4:4-7", "Eph. 1:5"]
+          "References": ["John.1.12-John.1.13", "Rom.8.15-Rom.8.16", "Gal.4.4-Gal.4.7", "Eph.1.5"]
         },
         {
           "Id": 4,
-          "References": ["Ps. 55:22", "Matt. 6:25, 26", "Luke 12:22-31"]
+          "References": ["Ps.55.22", "Matt.6.25-Matt.6.26", "Luke.12.22-Luke.12.31"]
         },
         {
           "Id": 5,
-          "References": ["Rom. 8:28"]
+          "References": ["Rom.8.28"]
         },
         {
           "Id": 6,
-          "References": ["Gen. 18:14", "Rom. 8:31-39"]
+          "References": ["Gen.18.14", "Rom.8.31-Rom.8.39"]
         },
         {
           "Id": 7,
-          "References": ["Matt. 6:32, 33", "Matt. 7:9-11."]
+          "References": ["Matt.6.32-Matt.6.33", "Matt.7.9-Matt.7.11"]
         }
       ]
     },
@@ -523,23 +523,23 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Jer. 23:23, 24", "Acts 17:24-28"]
+          "References": ["Jer.23.23-Jer.23.24", "Acts.17.24-Acts.17.28"]
         },
         {
           "Id": 2,
-          "References": ["Heb. 1:3"]
+          "References": ["Heb.1.3"]
         },
         {
           "Id": 3,
-          "References": ["Jer. 5:24", "Acts 14:15-17", "John 9:3", "Prov. 22:2"]
+          "References": ["Jer.5.24", "Acts.14.15-Acts.14.17", "John.9.3", "Prov.22.2"]
         },
         {
           "Id": 4,
-          "References": ["Prov. 16:33"]
+          "References": ["Prov.16.33"]
         },
         {
           "Id": 5,
-          "References": ["Matt. 10:29."]
+          "References": ["Matt.10.29"]
         }
       ]
     },
@@ -551,19 +551,19 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Job. 1:21, 22", "Ps. 39:10", "James 1:3"]
+          "References": ["Job.1.21-Job.1.22", "Ps.39.10", "Jas.1.3"]
         },
         {
           "Id": 2,
-          "References": ["Deut. 8:10", "I Thess. 5:18"]
+          "References": ["Deut.8.10", "1Thess.5.18"]
         },
         {
           "Id": 3,
-          "References": ["Ps. 55:22", "Rom. 5:3-5", "Rom. 8:38, 39"]
+          "References": ["Ps.55.22", "Rom.5.3-Rom.5.5", "Rom.8.38-Rom.8.39"]
         },
         {
           "Id": 4,
-          "References": ["Job 1:12", "Job 2:6", "Prov. 21:1", "Acts 17:24-28."]
+          "References": ["Job.1.12", "Job.2.6", "Prov.21.1", "Acts.17.24-Acts.17.28"]
         }
       ]
     },
@@ -575,11 +575,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 1:21", "Heb. 7:25"]
+          "References": ["Matt.1.21", "Heb.7.25"]
         },
         {
           "Id": 2,
-          "References": ["Is. 43:11", "John 15:4, 5", "Acts 4:11, 12", "I Tim. 2:5."]
+          "References": ["Isa.43.11", "John.15.4-John.15.5", "Acts.4.11-Acts.4.12", "1Tim.2.5"]
         }
       ]
     },
@@ -591,11 +591,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["I Cor. 1:12, 13", "Gal. 5:4"]
+          "References": ["1Cor.1.12-1Cor.1.13", "Gal.5.4"]
         },
         {
           "Id": 2,
-          "References": ["Col. 1:19, 20", "Col. 2:10", "I John 1:7."]
+          "References": ["Col.1.19-Col.1.20", "Col.2.10", "1John.1.7"]
         }
       ]
     },
@@ -607,35 +607,35 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ps. 45:7 (Heb. 1:9)", "Is. 61:1 (Luke 4:18", "Luke 3:21, 22"]
+          "References": ["Ps.45.7", "Heb.1.9", "Isa.61.1", "Luke.4.18", "Luke.3.21-Luke.3.22"]
         },
         {
           "Id": 2,
-          "References": ["Deut. 18:15 (Acts 3:22)"]
+          "References": ["Deut.18.15", "Acts.3.22"]
         },
         {
           "Id": 3,
-          "References": ["John 1:18", "John 15:15"]
+          "References": ["John.1.18", "John.15.15"]
         },
         {
           "Id": 4,
-          "References": ["Ps. 110:4 (Heb. 7:17)"]
+          "References": ["Ps.110.4", "Heb.7.17"]
         },
         {
           "Id": 5,
-          "References": ["Heb. 9:12", "Heb. 10:11-14"]
+          "References": ["Heb.9.12", "Heb.10.11-Heb.10.14"]
         },
         {
           "Id": 6,
-          "References": ["Rom. 8:34", "Heb. 9:24", "I John 2:1"]
+          "References": ["Rom.8.34", "Heb.9.24", "1John.2.1"]
         },
         {
           "Id": 7,
-          "References": ["Zach. 9:9 (Matt. 21:5)", "Luke 1:33"]
+          "References": ["Zech.9.9", "Matt.21.5", "Luke.1.33"]
         },
         {
           "Id": 8,
-          "References": ["Matt. 28:18-20", "John 10:28", "Rev. 12:10, 11."]
+          "References": ["Matt.28.18-Matt.28.20", "John.10.28", "Rev.12.10-Rev.12.11"]
         }
       ]
     },
@@ -647,27 +647,27 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["I Cor. 12:12-27"]
+          "References": ["1Cor.12.12-1Cor.12.27"]
         },
         {
           "Id": 2,
-          "References": ["Joel 2:28 (Acts 2:17)", "I John 2:27"]
+          "References": ["Joel.2.28", "Acts.2.17", "1John.2.27"]
         },
         {
           "Id": 3,
-          "References": ["Matt. 10:32", "Rom 10:9, 10", "Heb. 13:15"]
+          "References": ["Matt.10.32", "Rom.10.9-Rom.10.10", "Heb.13.15"]
         },
         {
           "Id": 4,
-          "References": ["Rom. 12:1", "I Pet. 2:5, 9"]
+          "References": ["Rom.12.1", "1Pet.2.5,1Pet.2.9"]
         },
         {
           "Id": 5,
-          "References": ["Gal. 5:16, 17", "Eph. 6:11", "I Tim. 1:18, 19"]
+          "References": ["Gal.5.16-Gal.5.17", "Eph.6.11", "1Tim.1.18-1Tim.1.19"]
         },
         {
           "Id": 6,
-          "References": ["Matt. 25:34", "II Tim. 2:12."]
+          "References": ["Matt.25.34", "2Tim.2.12"]
         }
       ]
     },
@@ -679,11 +679,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["John 1:1-3, 14, 18", "John 3:16", "Rom. 8:32", "Heb. 1", "I John 4:9"]
+          "References": ["John.1.1-John.1.3,John.1.14,John.1.18", "John.3.16", "Rom.8.32", "Heb.1", "1John.4.9"]
         },
         {
           "Id": 2,
-          "References": ["John 1:12", "Rom. 8:14-17", "Gal. 4:6", "Eph. 1:5, 6."]
+          "References": ["John.1.12", "Rom.8.14-Rom.8.17", "Gal.4.6", "Eph.1.5-Eph.1.6"]
         }
       ]
     },
@@ -695,15 +695,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["I Cor. 6:20", "I Tim. 2:5, 6"]
+          "References": ["1Cor.6.20", "1Tim.2.5-1Tim.2.6"]
         },
         {
           "Id": 2,
-          "References": ["I Peter 1:18, 19"]
+          "References": ["1Pet.1.18-1Pet.1.19"]
         },
         {
           "Id": 3,
-          "References": ["Col. 1:13, 14", "Heb. 2:14, 15."]
+          "References": ["Col.1.13-Col.1.14", "Heb.2.14-Heb.2.15"]
         }
       ]
     },
@@ -715,27 +715,27 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["John 1:1", "John 10:30-36", "Rom. 1:3", "Rom. 9:5", "Col. 1:15-17", "I John 5:20"]
+          "References": ["John.1.1", "John.10.30-John.10.36", "Rom.1.3", "Rom.9.5", "Col.1.15-Col.1.17", "1John.5.20"]
         },
         {
           "Id": 2,
-          "References": ["Matt. 1:18-23", "John 1:14", "Gal. 4:4", "Heb. 2:14"]
+          "References": ["Matt.1.18-Matt.1.23", "John.1.14", "Gal.4.4", "Heb.2.14"]
         },
         {
           "Id": 3,
-          "References": ["Luke 1:35"]
+          "References": ["Luke.1.35"]
         },
         {
           "Id": 4,
-          "References": ["II Sam. 7:12-16", "Ps. 132:11", "Matt. 1:1", "Luke 1:32", "Rom. 1:3"]
+          "References": ["2Sam.7.12-2Sam.7.16", "Ps.132.11", "Matt.1.1", "Luke.1.32", "Rom.1.3"]
         },
         {
           "Id": 5,
-          "References": ["Phil. 2:7", "Heb. 2:17"]
+          "References": ["Phil.2.7", "Heb.2.17"]
         },
         {
           "Id": 6,
-          "References": ["Heb. 4:15", "Heb. 7:26, 27."]
+          "References": ["Heb.4.15", "Heb.7.26-Heb.7.27"]
         }
       ]
     },
@@ -747,11 +747,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["I Tim. 2:5, 6", "Heb. 9:13-15"]
+          "References": ["1Tim.2.5-1Tim.2.6", "Heb.9.13-Heb.9.15"]
         },
         {
           "Id": 2,
-          "References": ["Rom. 8:3, 4", "II Cor. 5:21", "Gal. 4:4, 5", "I Pet. 1:18, 19."]
+          "References": ["Rom.8.3-Rom.8.4", "2Cor.5.21", "Gal.4.4-Gal.4.5", "1Pet.1.18-1Pet.1.19"]
         }
       ]
     },
@@ -763,19 +763,19 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Is. 53", "I Tim. 2:6", "I Pet. 2:24", "I Pet. 3:18"]
+          "References": ["Isa.53", "1Tim.2.6", "1Pet.2.24", "1Pet.3.18"]
         },
         {
           "Id": 2,
-          "References": ["Rom. 3:25", "I Cor. 5:7", "Eph. 5:2", "Heb. 10:14", "I John 2:2", "I John 4:10"]
+          "References": ["Rom.3.25", "1Cor.5.7", "Eph.5.2", "Heb.10.14", "1John.2.2", "1John.4.10"]
         },
         {
           "Id": 3,
-          "References": ["Rom. 8:1-4", "Gal. 3:13", "Col. 1:13", "Heb. 9:12", "I Pet 1:18, 19"]
+          "References": ["Rom.8.1-Rom.8.4", "Gal.3.13", "Col.1.13", "Heb.9.12", "1Pet.1.18-1Pet.1.19"]
         },
         {
           "Id": 4,
-          "References": ["John 3:16", "Rom. 3:24-26", "II Cor. 5:21", "Heb. 9:15."]
+          "References": ["John.3.16", "Rom.3.24-Rom.3.26", "2Cor.5.21", "Heb.9.15"]
         }
       ]
     },
@@ -787,11 +787,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Luke 23:13-24", "John 19:4, 12-16"]
+          "References": ["Luke.23.13-Luke.23.24", "John.19.4,John.19.12-John.19.16"]
         },
         {
           "Id": 2,
-          "References": ["Is. 53:4, 5", "II Cor. 5:21", "Gal. 3:13."]
+          "References": ["Isa.53.4-Isa.53.5", "2Cor.5.21", "Gal.3.13"]
         }
       ]
     },
@@ -803,7 +803,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Deut. 21:23", "Gal. 3:13."]
+          "References": ["Deut.21.23", "Gal.3.13"]
         }
       ]
     },
@@ -815,11 +815,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Gen. 2:17"]
+          "References": ["Gen.2.17"]
         },
         {
           "Id": 2,
-          "References": ["Rom. 8:3", "Phil. 2:8", "Heb. 2:9, 14, 15."]
+          "References": ["Rom.8.3", "Phil.2.8", "Heb.2.9,Heb.2.14-Heb.2.15"]
         }
       ]
     },
@@ -831,7 +831,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Is. 53:9", "John 19:38-42", "Acts 13:29", "I Cor. 15:3,4."]
+          "References": ["Isa.53.9", "John.19.38-John.19.42", "Acts.13.29", "1Cor.15.3-1Cor.15.4"]
         }
       ]
     },
@@ -843,7 +843,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["John 5:24", "Phil. 1:21-23", "I Thess. 5:9, 10."]
+          "References": ["John.5.24", "Phil.1.21-Phil.1.23", "1Thess.5.9-1Thess.5.10"]
         }
       ]
     },
@@ -855,15 +855,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Rom. 6:5-11", "Col. 2:11, 12"]
+          "References": ["Rom.6.5-Rom.6.11", "Col.2.11-Col.2.12"]
         },
         {
           "Id": 2,
-          "References": ["Rom. 6:12-14"]
+          "References": ["Rom.6.12-Rom.6.14"]
         },
         {
           "Id": 3,
-          "References": ["Rom. 12:1", "Eph. 5:1, 2."]
+          "References": ["Rom.12.1", "Eph.5.1-Eph.5.2"]
         }
       ]
     },
@@ -875,11 +875,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ps. 18:5, 6", "Ps. 116:3", "Matt. 26:36-46", "Matt. 27:45, 46", "Heb. 5:7-10"]
+          "References": ["Ps.18.5-Ps.18.6", "Ps.116.3", "Matt.26.36-Matt.26.46", "Matt.27.45-Matt.27.46", "Heb.5.7-Heb.5.10"]
         },
         {
           "Id": 2,
-          "References": ["Is. 53."]
+          "References": ["Isa.53"]
         }
       ]
     },
@@ -891,15 +891,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Rom. 4:25", "I Cor. 15:16-20", "I Pet. 1:3-5"]
+          "References": ["Rom.4.25", "1Cor.15.16-1Cor.15.20", "1Pet.1.3-1Pet.1.5"]
         },
         {
           "Id": 2,
-          "References": ["Rom. 6:5-11", "Eph. 2:4-6", "Col. 3:1-4"]
+          "References": ["Rom.6.5-Rom.6.11", "Eph.2.4-Eph.2.6", "Col.3.1-Col.3.4"]
         },
         {
           "Id": 3,
-          "References": ["Rom. 8:11", "I Cor. 15:12-23", "Phil. 3:20, 21."]
+          "References": ["Rom.8.11", "1Cor.15.12-1Cor.15.23", "Phil.3.20-Phil.3.21"]
         }
       ]
     },
@@ -911,15 +911,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Mark 16:19", "Luke 24:50, 51", "Acts 1:9-11"]
+          "References": ["Mark.16.19", "Luke.24.50-Luke.24.51", "Acts.1.9-Acts.1.11"]
         },
         {
           "Id": 2,
-          "References": ["Rom. 8:34", "Heb. 4:14", "Heb. 7:23-25", "Heb. 9:24"]
+          "References": ["Rom.8.34", "Heb.4.14", "Heb.7.23-Heb.7.25", "Heb.9.24"]
         },
         {
           "Id": 3,
-          "References": ["Matt. 24:30", "Acts 1:11."]
+          "References": ["Matt.24.30", "Acts.1.11"]
         }
       ]
     },
@@ -932,15 +932,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 28:20"]
+          "References": ["Matt.28.20"]
         },
         {
           "Id": 2,
-          "References": ["Matt. 26:11", "John 16:28", "John 17:11", "Acts 3:19-21", "Heb. 8:4"]
+          "References": ["Matt.26.11", "John.16.28", "John.17.11", "Acts.3.19-Acts.3.21", "Heb.8.4"]
         },
         {
           "Id": 3,
-          "References": ["Matt. 28:18-20", "John 14:16-19", "John 16:13."]
+          "References": ["Matt.28.18-Matt.28.20", "John.14.16-John.14.19", "John.16.13"]
         }
       ]
     },
@@ -952,11 +952,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Jer. 23:23, 24", "Acts 7:48, 49"]
+          "References": ["Jer.23.23-Jer.23.24", "Acts.7.48-Acts.7.49"]
         },
         {
           "Id": 2,
-          "References": ["John 1:14", "John 3:13", "Col. 2:9."]
+          "References": ["John.1.14", "John.3.13", "Col.2.9"]
         }
       ]
     },
@@ -968,19 +968,19 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Rom. 8:34", "I John 2:1"]
+          "References": ["Rom.8.34", "1John.2.1"]
         },
         {
           "Id": 2,
-          "References": ["John 14:2", "John 17:24", "Eph. 2:4-6"]
+          "References": ["John.14.2", "John.17.24", "Eph.2.4-Eph.2.6"]
         },
         {
           "Id": 3,
-          "References": ["John 14:16", "Acts 2:33", "II Cor. 1:21, 22", "II Cor. 5:5"]
+          "References": ["John.14.16", "Acts.2.33", "2Cor.1.21-2Cor.1.22", "2Cor.5.5"]
         },
         {
           "Id": 4,
-          "References": ["Col. 3:1-4."]
+          "References": ["Col.3.1-Col.3.4"]
         }
       ]
     },
@@ -992,11 +992,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Eph. 1:20-23", "Col. 1:18"]
+          "References": ["Eph.1.20-Eph.1.23", "Col.1.18"]
         },
         {
           "Id": 2,
-          "References": ["Matt. 28:18", "John 5:22, 23."]
+          "References": ["Matt.28.18", "John.5.22-John.5.23"]
         }
       ]
     },
@@ -1008,11 +1008,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Acts 2:33", "Eph. 4:7-12"]
+          "References": ["Acts.2.33", "Eph.4.7-Eph.4.12"]
         },
         {
           "Id": 2,
-          "References": ["Ps. 2:9", "Ps. 110:1, 2", "John 10:27-30", "Rev. 19:11-16."]
+          "References": ["Ps.2.9", "Ps.110.1-Ps.110.2", "John.10.27-John.10.30", "Rev.19.11-Rev.19.16"]
         }
       ]
     },
@@ -1024,11 +1024,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Luke 21:28", "Rom. 8:22-25", "Phil. 3:20,21", "Tit. 2:13, 14"]
+          "References": ["Luke.21.28", "Rom.8.22-Rom.8.25", "Phil.3.20-Phil.3.21", "Titus.2.13-Titus.2.14"]
         },
         {
           "Id": 2,
-          "References": ["Matt. 25:31-46", "I Thess. 4:16, 17", "II Thess. 1:6-10."]
+          "References": ["Matt.25.31-Matt.25.46", "1Thess.4.16-1Thess.4.17", "2Thess.1.6-2Thess.1.10"]
         }
       ]
     },
@@ -1040,23 +1040,23 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Gen. 1:1, 2", "Matt. 28:19", "Acts 5:3, 4", "I Cor. 3:16"]
+          "References": ["Gen.1.1-Gen.1.2", "Matt.28.19", "Acts.5.3-Acts.5.4", "1Cor.3.16"]
         },
         {
           "Id": 2,
-          "References": ["I Cor. 6:19", "II Cor. 1:21, 22", "Gal. 4:6", "Eph. 1:13"]
+          "References": ["1Cor.6.19", "2Cor.1.21-2Cor.1.22", "Gal.4.6", "Eph.1.13"]
         },
         {
           "Id": 3,
-          "References": ["Gal. 3:14", "I Pet. 1:2"]
+          "References": ["Gal.3.14", "1Pet.1.2"]
         },
         {
           "Id": 4,
-          "References": ["John 15:26", "Acts 9:31"]
+          "References": ["John.15.26", "Acts.9.31"]
         },
         {
           "Id": 5,
-          "References": ["John 14:16, 17", "I Pet. 4:14."]
+          "References": ["John.14.16-John.14.17", "1Pet.4.14"]
         }
       ]
     },
@@ -1068,39 +1068,39 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["John 10:11", "Acts 20:28", "Eph. 4:11-13", "Col. 1:18"]
+          "References": ["John.10.11", "Acts.20.28", "Eph.4.11-Eph.4.13", "Col.1.18"]
         },
         {
           "Id": 2,
-          "References": ["Gen. 26:4", "Rev. 5:9"]
+          "References": ["Gen.26.4", "Rev.5.9"]
         },
         {
           "Id": 3,
-          "References": ["Is. 59:21", "I Cor. 11:26"]
+          "References": ["Isa.59.21", "1Cor.11.26"]
         },
         {
           "Id": 4,
-          "References": ["Ps. 129:1-5", "Matt. 16:18", "John 10:28-30"]
+          "References": ["Ps.129.1-Ps.129.5", "Matt.16.18", "John.10.28-John.10.30"]
         },
         {
           "Id": 5,
-          "References": ["Rom. 1:16", "Rom. 10:14-17", "Eph. 5:26"]
+          "References": ["Rom.1.16", "Rom.10.14-Rom.10.17", "Eph.5.26"]
         },
         {
           "Id": 6,
-          "References": ["Acts 2:42-47", "Eph. 4:1-6"]
+          "References": ["Acts.2.42-Acts.2.47", "Eph.4.1-Eph.4.6"]
         },
         {
           "Id": 7,
-          "References": ["Rom. 8:29", "Eph. 1:3-14"]
+          "References": ["Rom.8.29", "Eph.1.3-Eph.1.14"]
         },
         {
           "Id": 8,
-          "References": ["I John 3:14, 19-21"]
+          "References": ["1John.3.14,1John.3.19-1John.3.21"]
         },
         {
           "Id": 9,
-          "References": ["Ps. 23:6", "John 10:27, 28", "I Cor. 1:4-9", "I Pet. 1:3-5."]
+          "References": ["Ps.23.6", "John.10.27-John.10.28", "1Cor.1.4-1Cor.1.9", "1Pet.1.3-1Pet.1.5"]
         }
       ]
     },
@@ -1112,11 +1112,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Rom. 8:32", "I Cor. 6:17", "I Cor. 12:4-7, 12, 13", "I John 1:3"]
+          "References": ["Rom.8.32", "1Cor.6.17", "1Cor.12.4-1Cor.12.7,1Cor.12.12-1Cor.12.13", "1John.1.3"]
         },
         {
           "Id": 2,
-          "References": ["Rom. 12:4-8", "I Cor. 12:20-27", "I Cor. 13:1-7", "Phil. 2:4-8."]
+          "References": ["Rom.12.4-Rom.12.8", "1Cor.12.20-1Cor.12.27", "1Cor.13.1-1Cor.13.7", "Phil.2.4-Phil.2.8"]
         }
       ]
     },
@@ -1128,15 +1128,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ps. 103:3, 4, 10, 12", "Mic. 7:18, 19", "II Cor. 5:18-21", "I John 1:7", "I John 2:2"]
+          "References": ["Ps.103.3-Ps.103.4,Ps.103.10,Ps.103.12", "Mic.7.18-Mic.7.19", "2Cor.5.18-2Cor.5.21", "1John.1.7", "1John.2.2"]
         },
         {
           "Id": 2,
-          "References": ["Rom. 7:21-25"]
+          "References": ["Rom.7.21-Rom.7.25"]
         },
         {
           "Id": 3,
-          "References": ["John 3:17, 18", "John 5:24", "Rom. 8:1, 2."]
+          "References": ["John.3.17-John.3.18", "John.5.24", "Rom.8.1-Rom.8.2"]
         }
       ]
     },
@@ -1148,11 +1148,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Luke 16:22", "Luke 23:43", "Phil. 1:21-23"]
+          "References": ["Luke.16.22", "Luke.23.43", "Phil.1.21-Phil.1.23"]
         },
         {
           "Id": 2,
-          "References": ["Job 19:25, 26", "I Cor. 15:20, 42-46, 54", "Phil. 3:21", "I John 3:2."]
+          "References": ["Job.19.25-Job.19.26", "1Cor.15.20,1Cor.15.42-1Cor.15.46,1Cor.15.54", "Phil.3.21", "1John.3.2"]
         }
       ]
     },
@@ -1164,11 +1164,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["John 17:3", "Rom. 14:17", "II Cor. 5:2, 3"]
+          "References": ["John.17.3", "Rom.14.17", "2Cor.5.2-2Cor.5.3"]
         },
         {
           "Id": 2,
-          "References": ["John 17:24", "I Cor. 2:9."]
+          "References": ["John.17.24", "1Cor.2.9"]
         }
       ]
     },
@@ -1180,7 +1180,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Hab. 2:4", "John 3:36", "Rom. 1:17", "Rom. 5:1, 2."]
+          "References": ["Hab.2.4", "John.3.36", "Rom.1.17", "Rom.5.1-Rom.5.2"]
         }
       ]
     },
@@ -1192,35 +1192,35 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Rom. 3:21-28", "Gal. 2:16", "Eph. 2:8, 9", "Phil. 3:8-11"]
+          "References": ["Rom.3.21-Rom.3.28", "Gal.2.16", "Eph.2.8-Eph.2.9", "Phil.3.8-Phil.3.11"]
         },
         {
           "Id": 2,
-          "References": ["Rom. 3:9, 10"]
+          "References": ["Rom.3.9-Rom.3.10"]
         },
         {
           "Id": 3,
-          "References": ["Rom. 7:23"]
+          "References": ["Rom.7.23"]
         },
         {
           "Id": 4,
-          "References": ["Deut. 9:6", "Ezek. 36:22", "Tit. 3:4, 5"]
+          "References": ["Deut.9.6", "Ezek.36.22", "Titus.3.4-Titus.3.5"]
         },
         {
           "Id": 5,
-          "References": ["Rom. 3:24", "Eph. 2:8"]
+          "References": ["Rom.3.24", "Eph.2.8"]
         },
         {
           "Id": 6,
-          "References": ["Rom. 4:3-5", "II Cor. 5:17-19", "I John 2:1, 2"]
+          "References": ["Rom.4.3-Rom.4.5", "2Cor.5.17-2Cor.5.19", "1John.2.1-1John.2.2"]
         },
         {
           "Id": 7,
-          "References": ["Rom. 4:24, 25", "II Cor. 5:21"]
+          "References": ["Rom.4.24-Rom.4.25", "2Cor.5.21"]
         },
         {
           "Id": 8,
-          "References": ["John 3:18", "Acts 16:30, 31", "Rom. 3:22."]
+          "References": ["John.3.18", "Acts.16.30-Acts.16.31", "Rom.3.22"]
         }
       ]
     },
@@ -1232,11 +1232,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["I Cor. 1:30, 31", "I Cor. 2:2"]
+          "References": ["1Cor.1.30-1Cor.1.31", "1Cor.2.2"]
         },
         {
           "Id": 2,
-          "References": ["Rom. 10:10", "I John 5:10-12."]
+          "References": ["Rom.10.10", "1John.5.10-1John.5.12"]
         }
       ]
     },
@@ -1248,11 +1248,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Deut. 27:26", "Gal. 3:10"]
+          "References": ["Deut.27.26", "Gal.3.10"]
         },
         {
           "Id": 2,
-          "References": ["Is. 64:6."]
+          "References": ["Isa.64.6"]
         }
       ]
     },
@@ -1264,11 +1264,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 5:12", "Heb. 11:6"]
+          "References": ["Matt.5.12", "Heb.11.6"]
         },
         {
           "Id": 2,
-          "References": ["Luke 17:10", "II Tim. 4:7, 8."]
+          "References": ["Luke.17.10", "2Tim.4.7-2Tim.4.8"]
         }
       ]
     },
@@ -1280,7 +1280,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 7:18", "Luke 6:43-45", "John 15:5."]
+          "References": ["Matt.7.18", "Luke.6.43-Luke.6.45", "John.15.5"]
         }
       ]
     },
@@ -1292,15 +1292,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["John 3:5", "I Cor. 2:10-14", "Eph. 2:8", "Phil. 1:29"]
+          "References": ["John.3.5", "1Cor.2.10-1Cor.2.14", "Eph.2.8", "Phil.1.29"]
         },
         {
           "Id": 2,
-          "References": ["Rom. 10:17", "I Pet. 1:23-25"]
+          "References": ["Rom.10.17", "1Pet.1.23-1Pet.1.25"]
         },
         {
           "Id": 3,
-          "References": ["Matt. 28:19, 20", "I Cor. 10:16."]
+          "References": ["Matt.28.19-Matt.28.20", "1Cor.10.16"]
         }
       ]
     },
@@ -1312,11 +1312,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Gen. 17:11", "Deut. 30:6", "Rom. 4:1"]
+          "References": ["Gen.17.11", "Deut.30.6", "Rom.4.1"]
         },
         {
           "Id": 2,
-          "References": ["Matt. 26:27, 28", "Acts 2:38", "Heb. 10:10."]
+          "References": ["Matt.26.27-Matt.26.28", "Acts.2.38", "Heb.10.10"]
         }
       ]
     },
@@ -1328,7 +1328,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Rom. 6:3", "I Cor. 11:26", "Gal. 3:27."]
+          "References": ["Rom.6.3", "1Cor.11.26", "Gal.3.27"]
         }
       ]
     },
@@ -1340,7 +1340,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 28:19, 20", "I Cor. 11:23-26. Holy Baptism"]
+          "References": ["Matt.28.19-Matt.28.20", "1Cor.11.23-1Cor.11.26"]
         }
       ]
     },
@@ -1352,11 +1352,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 28:19"]
+          "References": ["Matt.28.19"]
         },
         {
           "Id": 2,
-          "References": ["Matt. 3:11", "Mark 16:16", "John 1:33", "Acts 2:38", "Rom. 6:3, 4", "I Pet. 3:21. "]
+          "References": ["Matt.3.11", "Mark.16.16", "John.1.33", "Acts.2.38", "Rom.6.3-Rom.6.4", "1Pet.3.21"]
         }
       ]
     },
@@ -1368,11 +1368,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ez. 36:25", "Zech. 13:1", "Eph. 1:7", "Heb. 12:24", "I Pet. 1:2", "Rev. 1:5", "Rev. 7:14"]
+          "References": ["Ezek.36.25", "Zech.13.1", "Eph.1.7", "Heb.12.24", "1Pet.1.2", "Rev.1.5", "Rev.7.14"]
         },
         {
           "Id": 2,
-          "References": ["John 3:5-8", "Rom. 6:4", "I Cor. 6:11", "Col. 2:11, 12."]
+          "References": ["John.3.5-John.3.8", "Rom.6.4", "1Cor.6.11", "Col.2.11-Col.2.12"]
         }
       ]
     },
@@ -1384,15 +1384,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matthew 28:19"]
+          "References": ["Matt.28.19"]
         },
         {
           "Id": 2,
-          "References": ["Mark 16:16"]
+          "References": ["Mark.16.16"]
         },
         {
           "Id": 3,
-          "References": ["Titus 3:5", "Acts 22:16."]
+          "References": ["Titus.3.5", "Acts.22.16"]
         }
       ]
     },
@@ -1404,7 +1404,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 3:11", "I Pet. 3:21", "I John 1:7."]
+          "References": ["Matt.3.11", "1Pet.3.21", "1John.1.7"]
         }
       ]
     },
@@ -1416,11 +1416,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["I Cor. 6:11", "Rev. 1:5", "Rev. 7:14"]
+          "References": ["1Cor.6.11", "Rev.1.5", "Rev.7.14"]
         },
         {
           "Id": 2,
-          "References": ["Mark 16:16", "Acts 2:38", "Rom. 6:3, 4", "Gal. 3:27."]
+          "References": ["Mark.16.16", "Acts.2.38", "Rom.6.3-Rom.6.4", "Gal.3.27"]
         }
       ]
     },
@@ -1432,23 +1432,23 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Gen. 17:7", "Matt. 19:14"]
+          "References": ["Gen.17.7", "Matt.19.14"]
         },
         {
           "Id": 2,
-          "References": ["Ps. 22:11", "Is. 44:1-3", "Acts 2:38, 39", "Acts 16:31"]
+          "References": ["Ps.22.11", "Isa.44.1-Isa.44.3", "Acts.2.38-Acts.2.39", "Acts.16.31"]
         },
         {
           "Id": 3,
-          "References": ["Acts 10:47", "I Cor. 7:14"]
+          "References": ["Acts.10.47", "1Cor.7.14"]
         },
         {
           "Id": 4,
-          "References": ["Gen. 17:9-14"]
+          "References": ["Gen.17.9-Gen.17.14"]
         },
         {
           "Id": 5,
-          "References": ["Col. 2:11-13."]
+          "References": ["Col.2.11-Col.2.13"]
         }
       ]
     },
@@ -1460,7 +1460,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 26:26-28", "Mark 14:22-24", "Luke 22:19, 20", "I Cor. 11:23-25."]
+          "References": ["Matt.26.26-Matt.26.28", "Mark.14.22-Mark.14.24", "Luke.22.19-Luke.22.20", "1Cor.11.23-1Cor.11.25"]
         }
       ]
     },
@@ -1472,23 +1472,23 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["John 6:35, 40, 50-54"]
+          "References": ["John.6.35,John.6.40,John.6.50-John.6.54"]
         },
         {
           "Id": 2,
-          "References": ["John 6:55, 56", "I Cor. 12:13"]
+          "References": ["John.6.55-John.6.56", "1Cor.12.13"]
         },
         {
           "Id": 3,
-          "References": ["Acts 1:9-11", "Acts 3:21", "I Cor. 11:26", "Col. 3:1"]
+          "References": ["Acts.1.9-Acts.1.11", "Acts.3.21", "1Cor.11.26", "Col.3.1"]
         },
         {
           "Id": 4,
-          "References": ["I Cor. 6:15, 17", "Eph. 5:29, 30", "I John 4:13"]
+          "References": ["1Cor.6.15,1Cor.6.17", "Eph.5.29-Eph.5.30", "1John.4.13"]
         },
         {
           "Id": 5,
-          "References": ["John 6:56-58", "John 15:1-6", "Eph. 4:15, 16", "I John 3:24."]
+          "References": ["John.6.56-John.6.58", "John.15.1-John.15.6", "Eph.4.15-Eph.4.16", "1John.3.24"]
         }
       ]
     },
@@ -1500,11 +1500,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["I Corinthians 11:23-26"]
+          "References": ["1Cor.11.23-1Cor.11.26"]
         },
         {
           "Id": 2,
-          "References": ["I Corinthians 10:16, 17"]
+          "References": ["1Cor.10.16-1Cor.10.17"]
         }
       ]
     },
@@ -1516,19 +1516,19 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Eph. 5:26", "Tit. 3:5"]
+          "References": ["Eph.5.26", "Titus.3.5"]
         },
         {
           "Id": 2,
-          "References": ["Matt. 26:26-29"]
+          "References": ["Matt.26.26-Matt.26.29"]
         },
         {
           "Id": 3,
-          "References": ["I Cor. 10:16, 17", "I Cor. 11:26-28"]
+          "References": ["1Cor.10.16-1Cor.10.17", "1Cor.11.26-1Cor.11.28"]
         },
         {
           "Id": 4,
-          "References": ["Gen. 17:10, 11", "Ex. 12:11, 13", "I Cor. 10:3, 4", "I Pet. 3:21."]
+          "References": ["Gen.17.10-Gen.17.11", "Exod.12.11,Exod.12.13", "1Cor.10.3-1Cor.10.4", "1Pet.3.21"]
         }
       ]
     },
@@ -1540,15 +1540,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["John 6:51, 55"]
+          "References": ["John.6.51,John.6.55"]
         },
         {
           "Id": 2,
-          "References": ["I Cor. 10:16, 17", "I Cor. 11:26"]
+          "References": ["1Cor.10.16-1Cor.10.17", "1Cor.11.26"]
         },
         {
           "Id": 3,
-          "References": ["Rom. 6:5-11."]
+          "References": ["Rom.6.5-Rom.6.11"]
         }
       ]
     },
@@ -1560,19 +1560,19 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 26:28", "John 19:30", "Heb. 7:27", "Heb. 9:12, 25, 26", "Heb. 10:10-18"]
+          "References": ["Matt.26.28", "John.19.30", "Heb.7.27", "Heb.9.12,Heb.9.25-Heb.9.26", "Heb.10.10-Heb.10.18"]
         },
         {
           "Id": 2,
-          "References": ["I Cor. 6:17", "I Cor. 10:16, 17"]
+          "References": ["1Cor.6.17", "1Cor.10.16-1Cor.10.17"]
         },
         {
           "Id": 3,
-          "References": ["Joh. 20:17", "Acts 7:55, 56", "Heb. 1:3", "Heb. 8:1"]
+          "References": ["John.20.17", "Acts.7.55-Acts.7.56", "Heb.1.3", "Heb.8.1"]
         },
         {
           "Id": 4,
-          "References": ["John 4:21-24", "Phil. 3:20", "Col. 3:1", "I Thess. 1:10."]
+          "References": ["John.4.21-John.4.24", "Phil.3.20", "Col.3.1", "1Thess.1.10"]
         }
       ]
     },
@@ -1584,7 +1584,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["I Cor. 10:19-22", "I Cor. 11:26-32."]
+          "References": ["1Cor.10.19-1Cor.10.22", "1Cor.11.26-1Cor.11.32"]
         }
       ]
     },
@@ -1596,7 +1596,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ps. 50:16", "Is. 1:11-17", "I Cor. 11:17-34."]
+          "References": ["Ps.50.16", "Isa.1.11-Isa.1.17", "1Cor.11.17-1Cor.11.34"]
         }
       ]
     },
@@ -1608,7 +1608,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 16:19", "John 20:21-23."]
+          "References": ["Matt.16.19", "John.20.21-John.20.23"]
         }
       ]
     },
@@ -1620,7 +1620,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 16:19", "John 3:31-36", "John 20:21-23."]
+          "References": ["Matt.16.19", "John.3.31-John.3.36", "John.20.21-John.20.23"]
         }
       ]
     },
@@ -1632,11 +1632,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 18:15-20", "I Cor. 5:3-5", "11-13", "II Thess. 3:14, 15"]
+          "References": ["Matt.18.15-Matt.18.20", "1Cor.5.3-1Cor.5.5,1Cor.5.11-1Cor.5.13", "2Thess.3.14-2Thess.3.15"]
         },
         {
           "Id": 2,
-          "References": ["Luke 15:20-24", "II Cor. 2:6-11."]
+          "References": ["Luke.15.20-Luke.15.24", "2Cor.2.6-2Cor.2.11"]
         }
       ]
     },
@@ -1648,19 +1648,19 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Rom. 6:13", "Rom. 12:1, 2", "I Pet. 2:5-10"]
+          "References": ["Rom.6.13", "Rom.12.1-Rom.12.2", "1Pet.2.5-1Pet.2.10"]
         },
         {
           "Id": 2,
-          "References": ["Matt. 5:16", "I Cor. 6:19, 20"]
+          "References": ["Matt.5.16", "1Cor.6.19-1Cor.6.20"]
         },
         {
           "Id": 3,
-          "References": ["Matt. 7:17, 18", "Gal. 5:22-24", "II Pet. 1:10, 11"]
+          "References": ["Matt.7.17-Matt.7.18", "Gal.5.22-Gal.5.24", "2Pet.1.10-2Pet.1.11"]
         },
         {
           "Id": 4,
-          "References": ["Matt. 5:14-16", "Rom. 14:17-19", "I Pet. 2:12", "I Pet. 3:1, 2."]
+          "References": ["Matt.5.14-Matt.5.16", "Rom.14.17-Rom.14.19", "1Pet.2.12", "1Pet.3.1-1Pet.3.2"]
         }
       ]
     },
@@ -1672,7 +1672,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["I Cor. 6:9, 10", "Gal. 5:19-21", "Eph. 5:5, 6", "I John 3:14."]
+          "References": ["1Cor.6.9-1Cor.6.10", "Gal.5.19-Gal.5.21", "Eph.5.5-Eph.5.6", "1John.3.14"]
         }
       ]
     },
@@ -1684,7 +1684,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Rom. 6:1-11", "I Cor. 5:7", "II Cor. 5:17", "Eph. 4:22-24", "Col. 3:5-10."]
+          "References": ["Rom.6.1-Rom.6.11", "1Cor.5.7", "2Cor.5.17", "Eph.4.22-Eph.4.24", "Col.3.5-Col.3.10"]
         }
       ]
     },
@@ -1696,7 +1696,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ps. 51:3, 4, 17", "Joel 2:12, 13", "Rom. 8:12, 13", "II Cor. 7:10."]
+          "References": ["Ps.51.3-Ps.51.4,Ps.51.17", "Joel.2.12-Joel.2.13", "Rom.8.12-Rom.8.13", "2Cor.7.10"]
         }
       ]
     },
@@ -1708,11 +1708,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ps. 51:8, 12", "Is. 57:15", "Rom. 5:1", "Rom. 14:17"]
+          "References": ["Ps.51.8,Ps.51.12", "Isa.57.15", "Rom.5.1", "Rom.14.17"]
         },
         {
           "Id": 2,
-          "References": ["Rom. 6:10, 11", "Gal. 2:20."]
+          "References": ["Rom.6.10-Rom.6.11", "Gal.2.20"]
         }
       ]
     },
@@ -1724,19 +1724,19 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Joh. 15:5", "Rom. 14:23", "Heb. 11:6"]
+          "References": ["John.15.5", "Rom.14.23", "Heb.11.6"]
         },
         {
           "Id": 2,
-          "References": ["Lev. 18:4", "I Sam. 15:22", "Eph. 2:10"]
+          "References": ["Lev.18.4", "1Sam.15.22", "Eph.2.10"]
         },
         {
           "Id": 3,
-          "References": ["I Cor. 10:31"]
+          "References": ["1Cor.10.31"]
         },
         {
           "Id": 4,
-          "References": ["Deut. 12:32", "Is. 29:13", "Ezek. 20:18, 19", "Matt. 15:7-9."]
+          "References": ["Deut.12.32", "Isa.29.13", "Ezek.20.18-Ezek.20.19", "Matt.15.7-Matt.15.9"]
         }
       ]
     },
@@ -1748,7 +1748,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ex. 20:1-17", "Deut. 5:6-21."]
+          "References": ["Exod.20.1-Exod.20.17", "Deut.5.6-Deut.5.21"]
         }
       ]
     },
@@ -1760,7 +1760,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 22:37-40."]
+          "References": ["Matt.22.37-Matt.22.40"]
         }
       ]
     },
@@ -1772,51 +1772,51 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["I Cor. 6:9, 10", "I Cor. 10:5-14", "I John 5:21"]
+          "References": ["1Cor.6.9-1Cor.6.10", "1Cor.10.5-1Cor.10.14", "1John.5.21"]
         },
         {
           "Id": 2,
-          "References": ["Lev. 19:31", "Deut. 18:9-12"]
+          "References": ["Lev.19.31", "Deut.18.9-Deut.18.12"]
         },
         {
           "Id": 3,
-          "References": ["Matt. 4:10", "Rev. 19:10", "Rev. 22:8, 9"]
+          "References": ["Matt.4.10", "Rev.19.10", "Rev.22.8-Rev.22.9"]
         },
         {
           "Id": 4,
-          "References": ["John 17:3"]
+          "References": ["John.17.3"]
         },
         {
           "Id": 5,
-          "References": ["Jer. 17:5, 7"]
+          "References": ["Jer.17.5,Jer.17.7"]
         },
         {
           "Id": 6,
-          "References": ["I Pet. 5:5, 6"]
+          "References": ["1Pet.5.5-1Pet.5.6"]
         },
         {
           "Id": 7,
-          "References": ["Rom. 5:3, 4", "I Cor. 10:10", "Phil. 2:14", "Col. 1:11", "Heb. 10:36"]
+          "References": ["Rom.5.3-Rom.5.4", "1Cor.10.10", "Phil.2.14", "Col.1.11", "Heb.10.36"]
         },
         {
           "Id": 8,
-          "References": ["Ps. 104:27, 28", "Is. 45:7", "James 1:17"]
+          "References": ["Ps.104.27-Ps.104.28", "Isa.45.7", "Jas.1.17"]
         },
         {
           "Id": 9,
-          "References": ["Deut. 6:5", "(Matt. 22:37)"]
+          "References": ["Deut.6.5", "Matt.22.37"]
         },
         {
           "Id": 10,
-          "References": ["Deut. 6:2", "Ps. 111:10", "Prov. 1:7", "Prov. 9:10", "Matt. 10:28", "I Pet. 1:17"]
+          "References": ["Deut.6.2", "Ps.111.10", "Prov.1.7", "Prov.9.10", "Matt.10.28", "1Pet.1.17"]
         },
         {
           "Id": 11,
-          "References": ["Deut. 6:13", "(Matt. 4:10)", "Deut. 10:20"]
+          "References": ["Deut.6.13", "Matt.4.10", "Deut.10.20"]
         },
         {
           "Id": 12,
-          "References": ["Matt. 5:29, 30", "Matt. 10:37-39", "Acts 5:29."]
+          "References": ["Matt.5.29-Matt.5.30", "Matt.10.37-Matt.10.39", "Acts.5.29"]
         }
       ]
     },
@@ -1828,7 +1828,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["I Chron. 16:26", "Gal. 4:8, 9", "Eph. 5:5", "Phil. 3:19."]
+          "References": ["1Chr.16.26", "Gal.4.8-Gal.4.9", "Eph.5.5", "Phil.3.19"]
         }
       ]
     },
@@ -1840,11 +1840,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Deut. 4:15-19", "Is. 40:18-25", "Acts 17:29", "Rom. 1:23"]
+          "References": ["Deut.4.15-Deut.4.19", "Isa.40.18-Isa.40.25", "Acts.17.29", "Rom.1.23"]
         },
         {
           "Id": 2,
-          "References": ["Lev. 10:1-7", "Deut. 12:30", "I Sam. 15:22, 23", "Matt. 15:9", "John 4:23, 24."]
+          "References": ["Lev.10.1-Lev.10.7", "Deut.12.30", "1Sam.15.22-1Sam.15.23", "Matt.15.9", "John.4.23-John.4.24"]
         }
       ]
     },
@@ -1856,7 +1856,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ex. 34:13, 14, 17", "Num. 33:52", "II Kings 18:4, 5", "Is. 40:25."]
+          "References": ["Exod.34.13-Exod.34.14,Exod.34.17", "Num.33.52", "2Kgs.18.4-2Kgs.18.5", "Isa.40.25"]
         }
       ]
     },
@@ -1868,11 +1868,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Jer. 10:8", "Hab. 2:18-20"]
+          "References": ["Jer.10.8", "Hab.2.18-Hab.2.20"]
         },
         {
           "Id": 2,
-          "References": ["Rom. 10:14, 15, 17", "II Tim. 3:16, 17", "II Pet. 1:19."]
+          "References": ["Rom.10.14-Rom.10.15,Rom.10.17", "2Tim.3.16-2Tim.3.17", "2Pet.1.19"]
         }
       ]
     },
@@ -1884,35 +1884,35 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Lev. 24:10-17"]
+          "References": ["Lev.24.10-Lev.24.17"]
         },
         {
           "Id": 2,
-          "References": ["Lev. 19:1"]
+          "References": ["Lev.19.1"]
         },
         {
           "Id": 3,
-          "References": ["Matt. 5:37", "James 5:12"]
+          "References": ["Matt.5.37", "Jas.5.12"]
         },
         {
           "Id": 4,
-          "References": ["Lev. 5:1", "Prov. 29:24"]
+          "References": ["Lev.5.1", "Prov.29.24"]
         },
         {
           "Id": 5,
-          "References": ["Ps. 99:1-5", "Is. 45:23", "Jer. 4:2"]
+          "References": ["Ps.99.1-Ps.99.5", "Isa.45.23", "Jer.4.2"]
         },
         {
           "Id": 6,
-          "References": ["Matt. 10:32, 33", "Rom. 10:9, 10"]
+          "References": ["Matt.10.32-Matt.10.33", "Rom.10.9-Rom.10.10"]
         },
         {
           "Id": 7,
-          "References": ["Ps. 50:14, 15", "I Tim. 2:8"]
+          "References": ["Ps.50.14-Ps.50.15", "1Tim.2.8"]
         },
         {
           "Id": 8,
-          "References": ["Rom. 2:24", "Col. 3:17", "I Tim. 6:1."]
+          "References": ["Rom.2.24", "Col.3.17", "1Tim.6.1"]
         }
       ]
     },
@@ -1924,11 +1924,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Lev. 5:1"]
+          "References": ["Lev.5.1"]
         },
         {
           "Id": 2,
-          "References": ["Lev. 24:16."]
+          "References": ["Lev.24.16"]
         }
       ]
     },
@@ -1940,11 +1940,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Deut. 6:13", "Deut. 10:20", "Jer. 4:1, 2", "Heb. 6:16"]
+          "References": ["Deut.6.13", "Deut.10.20", "Jer.4.1-Jer.4.2", "Heb.6.16"]
         },
         {
           "Id": 2,
-          "References": ["Gen. 21:24", "Gen. 31:53", "Josh. 9:15", "I Sam. 24:22", "I Kings 1:29, 30", "Rom. 1:9", "II Cor. 1:23."]
+          "References": ["Gen.21.24", "Gen.31.53", "Josh.9.15", "1Sam.24.22", "1Kgs.1.29-1Kgs.1.30", "Rom.1.9", "2Cor.1.23"]
         }
       ]
     },
@@ -1956,11 +1956,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Rom. 9:1", "II Cor. 1:23"]
+          "References": ["Rom.9.1", "2Cor.1.23"]
         },
         {
           "Id": 2,
-          "References": ["Matt. 5:34-37", "Matt. 23:16-22", "James 5:12."]
+          "References": ["Matt.5.34-Matt.5.37", "Matt.23.16-Matt.23.22", "Jas.5.12"]
         }
       ]
     },
@@ -1972,31 +1972,31 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Deut. 6:4-9", "20-25", "I Cor. 9:13, 14", "II Tim. 2:2", "II Tim. 3:13-17", "Tit. 1:5"]
+          "References": ["Deut.6.4-Deut.6.9,Deut.6.20-Deut.6.25", "1Cor.9.13-1Cor.9.14", "2Tim.2.2", "2Tim.3.13-2Tim.3.17", "Titus.1.5"]
         },
         {
           "Id": 2,
-          "References": ["Deut. 12:5-12", "Ps. 40:9, 10", "Ps. 68:26", "Acts 2:42-47", "Heb. 10:23-25"]
+          "References": ["Deut.12.5-Deut.12.12", "Ps.40.9-Ps.40.10", "Ps.68.26", "Acts.2.42-Acts.2.47", "Heb.10.23-Heb.10.25"]
         },
         {
           "Id": 3,
-          "References": ["Rom. 10:14-17", "I Cor. 14:26-33", "I Tim. 4:13"]
+          "References": ["Rom.10.14-Rom.10.17", "1Cor.14.26-1Cor.14.33", "1Tim.4.13"]
         },
         {
           "Id": 4,
-          "References": ["I Cor. 11:23, 24"]
+          "References": ["1Cor.11.23-1Cor.11.24"]
         },
         {
           "Id": 5,
-          "References": ["Col. 3:16", "I Tim. 2:1"]
+          "References": ["Col.3.16", "1Tim.2.1"]
         },
         {
           "Id": 6,
-          "References": ["Ps. 50:14", "I Cor. 16:2", "II Cor. 8 and 9"]
+          "References": ["Ps.50.14", "1Cor.16.2", "2Cor.8-2Cor.9"]
         },
         {
           "Id": 7,
-          "References": ["Is. 66:23", "Heb. 4:9-11."]
+          "References": ["Isa.66.23", "Heb.4.9-Heb.4.11"]
         }
       ]
     },
@@ -2008,15 +2008,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ex. 21:17", "Prov. 1:8", "Prov. 4:1", "Rom. 13:1, 2", "Eph. 5:21, 22", "Eph. 6:1-9", "Col. 3:18-4:1"]
+          "References": ["Exod.21.17", "Prov.1.8", "Prov.4.1", "Rom.13.1-Rom.13.2", "Eph.5.21-Eph.5.22", "Eph.6.1-Eph.6.9", "Col.3.18-Col.4.1"]
         },
         {
           "Id": 2,
-          "References": ["Prov. 20:20", "Prov. 23:22", "I Pet.2:18"]
+          "References": ["Prov.20.20", "Prov.23.22", "1Pet.2.18"]
         },
         {
           "Id": 3,
-          "References": ["Matt. 22:21, Rom. 13:1-8", "Eph. 6:1-9", "Col. 3:18-21."]
+          "References": ["Matt.22.21,Rom.13.1-Rom.13.8", "Eph.6.1-Eph.6.9", "Col.3.18-Col.3.21"]
         }
       ]
     },
@@ -2028,19 +2028,19 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Gen. 9:6", "Lev. 19:17, 18", "Matt. 5:21, 22", "Matt. 26:52"]
+          "References": ["Gen.9.6", "Lev.19.17-Lev.19.18", "Matt.5.21-Matt.5.22", "Matt.26.52"]
         },
         {
           "Id": 2,
-          "References": ["Prov. 25:21, 22", "Matt. 18:35", "Rom. 12:19", "Eph. 4:26"]
+          "References": ["Prov.25.21-Prov.25.22", "Matt.18.35", "Rom.12.19", "Eph.4.26"]
         },
         {
           "Id": 3,
-          "References": ["Matt. 4:7", "Matt. 26:52", "Rom. 13:11-14"]
+          "References": ["Matt.4.7", "Matt.26.52", "Rom.13.11-Rom.13.14"]
         },
         {
           "Id": 4,
-          "References": ["Gen. 9:6", "Ex. 21:14", "Rom. 13:4."]
+          "References": ["Gen.9.6", "Exod.21.14", "Rom.13.4"]
         }
       ]
     },
@@ -2052,11 +2052,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Prov. 14:30", "Rom. 1:29", "Rom. 12:19", "Gal. 5:19-21", "James 1:20", "I John 2:9-11"]
+          "References": ["Prov.14.30", "Rom.1.29", "Rom.12.19", "Gal.5.19-Gal.5.21", "Jas.1.20", "1John.2.9-1John.2.11"]
         },
         {
           "Id": 2,
-          "References": ["I John 3:15."]
+          "References": ["1John.3.15"]
         }
       ]
     },
@@ -2068,15 +2068,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 7:12", "Matt. 22:39", "Rom. 12:10"]
+          "References": ["Matt.7.12", "Matt.22.39", "Rom.12.10"]
         },
         {
           "Id": 2,
-          "References": ["Matt. 5:5", "Luke 6:36", "Rom. 12:10, 18", "Gal. 6:1, 2", "Eph. 4:2", "Col. 3:12", "IPet. 3:8"]
+          "References": ["Matt.5.5", "Luke.6.36", "Rom.12.10,Rom.12.18", "Gal.6.1-Gal.6.2", "Eph.4.2", "Col.3.12", "1Pet.3.8"]
         },
         {
           "Id": 3,
-          "References": ["Ex. 23:4, 5", "Matt. 5:44, 45", "Rom. 12:20."]
+          "References": ["Exod.23.4-Exod.23.5", "Matt.5.44-Matt.5.45", "Rom.12.20"]
         }
       ]
     },
@@ -2088,15 +2088,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Lev. 18:30", "Eph. 5:3-5"]
+          "References": ["Lev.18.30", "Eph.5.3-Eph.5.5"]
         },
         {
           "Id": 2,
-          "References": ["Jude 22, 23"]
+          "References": ["Jude.1.22-Jude.1.23"]
         },
         {
           "Id": 3,
-          "References": ["I Cor. 7:1-9", "I Thess. 4:3-8", "Heb. 13:4."]
+          "References": ["1Cor.7.1-1Cor.7.9", "1Thess.4.3-1Thess.4.8", "Heb.13.4"]
         }
       ]
     },
@@ -2108,11 +2108,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 5:27-29", "I Cor. 6:18-20", "Eph. 5:3, 4"]
+          "References": ["Matt.5.27-Matt.5.29", "1Cor.6.18-1Cor.6.20", "Eph.5.3-Eph.5.4"]
         },
         {
           "Id": 2,
-          "References": ["I Cor. 15:33", "Eph. 5:18."]
+          "References": ["1Cor.15.33", "Eph.5.18"]
         }
       ]
     },
@@ -2124,23 +2124,23 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ex. 22:1", "I Cor. 5:9, 10", "I Cor. 6:9, 10"]
+          "References": ["Exod.22.1", "1Cor.5.9-1Cor.5.10", "1Cor.6.9-1Cor.6.10"]
         },
         {
           "Id": 2,
-          "References": ["Deut. 25:13-16", "Ps. 15:5", "Prov. 11:1", "Prov. 12:22", "Ezek. 45:9-12", "Luke 6:35"]
+          "References": ["Deut.25.13-Deut.25.16", "Ps.15.5", "Prov.11.1", "Prov.12.22", "Ezek.45.9-Ezek.45.12", "Luke.6.35"]
         },
         {
           "Id": 3,
-          "References": ["Mic. 6:9-11", "Luke 3:14", "James 5:1-6"]
+          "References": ["Mic.6.9-Mic.6.11", "Luke.3.14", "Jas.5.1-Jas.5.6"]
         },
         {
           "Id": 4,
-          "References": ["Luke 12:15", "Eph. 5:5"]
+          "References": ["Luke.12.15", "Eph.5.5"]
         },
         {
           "Id": 5,
-          "References": ["Prov. 21:20", "Prov. 23:20, 21", "Luke 16:10-13."]
+          "References": ["Prov.21.20", "Prov.23.20-Prov.23.21", "Luke.16.10-Luke.16.13"]
         }
       ]
     },
@@ -2152,7 +2152,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Is. 58:5-10", "Matt. 7:12", "Gal. 6:9, 10", "Eph. 4:28."]
+          "References": ["Isa.58.5-Isa.58.10", "Matt.7.12", "Gal.6.9-Gal.6.10", "Eph.4.28"]
         }
       ]
     },
@@ -2164,19 +2164,19 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ps. 15", "Prov. 19:5, 9", "Prov. 21:28", "Matt. 7:1", "Luke 6:37", "Rom. 1:28-32"]
+          "References": ["Ps.15", "Prov.19.5,Prov.19.9", "Prov.21.28", "Matt.7.1", "Luke.6.37", "Rom.1.28-Rom.1.32"]
         },
         {
           "Id": 2,
-          "References": ["Lev. 19:11, 12", "Prov. 12:22", "Prov. 13:5", "John 8:44", "Rev. 21:8"]
+          "References": ["Lev.19.11-Lev.19.12", "Prov.12.22", "Prov.13.5", "John.8.44", "Rev.21.8"]
         },
         {
           "Id": 3,
-          "References": ["I Cor. 13:6", "Eph. 4:25"]
+          "References": ["1Cor.13.6", "Eph.4.25"]
         },
         {
           "Id": 4,
-          "References": ["I Pet. 3:8, 9", "I Pet. 4:8."]
+          "References": ["1Pet.3.8-1Pet.3.9", "1Pet.4.8"]
         }
       ]
     },
@@ -2188,7 +2188,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ps. 19:7-14", "Ps. 139:23, 24", "Rom. 7:7, 8."]
+          "References": ["Ps.19.7-Ps.19.14", "Ps.139.23-Ps.139.24", "Rom.7.7-Rom.7.8"]
         }
       ]
     },
@@ -2200,11 +2200,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Eccles. 7:20", "Rom. 7:14, 15", "I Cor. 13:9", "I John 1:8"]
+          "References": ["Eccl.7.20", "Rom.7.14-Rom.7.15", "1Cor.13.9", "1John.1.8"]
         },
         {
           "Id": 2,
-          "References": ["Ps. 1:1, 2", "Rom. 7:22-25", "Phil. 3:12-16."]
+          "References": ["Ps.1.1-Ps.1.2", "Rom.7.22-Rom.7.25", "Phil.3.12-Phil.3.16"]
         }
       ]
     },
@@ -2216,11 +2216,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ps. 32:5", "Rom. 3:19-26", "Rom. 7:7, 24, 25", "I John 1:9"]
+          "References": ["Ps.32.5", "Rom.3.19-Rom.3.26", "Rom.7.7,Rom.7.24-Rom.7.25", "1John.1.9"]
         },
         {
           "Id": 2,
-          "References": ["I Cor. 9:24", "Phil. 3:12-14", "I John 3:1-3."]
+          "References": ["1Cor.9.24", "Phil.3.12-Phil.3.14", "1John.3.1-1John.3.3"]
         }
       ]
     },
@@ -2232,11 +2232,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ps. 50:14, 15", "Ps. 116:12-19", "I Thess. 5:16-18"]
+          "References": ["Ps.50.14-Ps.50.15", "Ps.116.12-Ps.116.19", "1Thess.5.16-1Thess.5.18"]
         },
         {
           "Id": 2,
-          "References": ["Matt. 7:7, 8", "Luke 11:9-13."]
+          "References": ["Matt.7.7-Matt.7.8", "Luke.11.9-Luke.11.13"]
         }
       ]
     },
@@ -2248,15 +2248,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ps. 145:18-20", "John 4:22-24", "Rom. 8:26, 27", "James 1:5", "I John 5:14, 15", "Rev. 19:10"]
+          "References": ["Ps.145.18-Ps.145.20", "John.4.22-John.4.24", "Rom.8.26-Rom.8.27", "Jas.1.5", "1John.5.14-1John.5.15", "Rev.19.10"]
         },
         {
           "Id": 2,
-          "References": ["II Chron. 7:14", "II Chron. 20:12", "Ps. 2:11", "Ps. 34:18", "Ps. 62:8", "Is. 66:2", "Rev. 4"]
+          "References": ["2Chr.7.14", "2Chr.20.12", "Ps.2.11", "Ps.34.18", "Ps.62.8", "Isa.66.2", "Rev.4"]
         },
         {
           "Id": 3,
-          "References": ["Dan. 9:17-19", "Matt. 7:8", "John 14:13, 14", "John 16:23", "Rom. 10:13", "James 1:6."]
+          "References": ["Dan.9.17-Dan.9.19", "Matt.7.8", "John.14.13-John.14.14", "John.16.23", "Rom.10.13", "Jas.1.6"]
         }
       ]
     },
@@ -2268,7 +2268,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 6:33", "James 1:17."]
+          "References": ["Matt.6.33", "Jas.1.17"]
         }
       ]
     },
@@ -2280,7 +2280,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 6:9-13", "Luke 11:2-4."]
+          "References": ["Matt.6.9-Matt.6.13", "Luke.11.2-Luke.11.4"]
         }
       ]
     },
@@ -2292,7 +2292,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 7:9-11", "Luke 11:11-13."]
+          "References": ["Matt.7.9-Matt.7.11", "Luke.11.11-Luke.11.13"]
         }
       ]
     },
@@ -2304,11 +2304,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Jer.23:23,24", "Acts 17:24, 25"]
+          "References": ["Jer.23.23-Jer.23.24", "Acts.17.24-Acts.17.25"]
         },
         {
           "Id": 2,
-          "References": ["Mt.6:25-34", "Rom.8:31,32."]
+          "References": ["Matt.6.25-Matt.6.34", "Rom.8.31-Rom.8.32"]
         }
       ]
     },
@@ -2320,15 +2320,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Jer. 9:23, 24", "Jer. 31:33, 34", "Matt. 16:17", "John 17:3"]
+          "References": ["Jer.9.23-Jer.9.24", "Jer.31.33-Jer.31.34", "Matt.16.17", "John.17.3"]
         },
         {
           "Id": 2,
-          "References": ["Ex. 34:5-8", "Ps. 145", "Jer. 32:16-20", "Luke 1:46-55, 68-75", "Rom. 11:33-36"]
+          "References": ["Exod.34.5-Exod.34.8", "Ps.145", "Jer.32.16-Jer.32.20", "Luke.1.46-Luke.1.55,Luke.1.68-Luke.1.75", "Rom.11.33-Rom.11.36"]
         },
         {
           "Id": 3,
-          "References": ["Ps. 115:1", "Matt. 5:16."]
+          "References": ["Ps.115.1", "Matt.5.16"]
         }
       ]
     },
@@ -2340,19 +2340,19 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ps. 119:5, 105", "Ps. 143:10", "Matt. 6:33"]
+          "References": ["Ps.119.5,Ps.119.105", "Ps.143.10", "Matt.6.33"]
         },
         {
           "Id": 2,
-          "References": ["Ps. 51:18", "Ps. 122:6-9", "Matt. 16:18", "Acts 2:42-47"]
+          "References": ["Ps.51.18", "Ps.122.6-Ps.122.9", "Matt.16.18", "Acts.2.42-Acts.2.47"]
         },
         {
           "Id": 3,
-          "References": ["Rom. 16:20", "I John 3:8"]
+          "References": ["Rom.16.20", "1John.3.8"]
         },
         {
           "Id": 4,
-          "References": ["Rom. 8:22, 23", "I Cor. 15:28", "Rev. 22:17, 20."]
+          "References": ["Rom.8.22-Rom.8.23", "1Cor.15.28", "Rev.22.17,Rev.22.20"]
         }
       ]
     },
@@ -2364,15 +2364,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 7:21", "Matt. 16:24-26", "Luke 22:42", "Rom. 12:1, 2", "Tit. 2:11, 12"]
+          "References": ["Matt.7.21", "Matt.16.24-Matt.16.26", "Luke.22.42", "Rom.12.1-Rom.12.2", "Titus.2.11-Titus.2.12"]
         },
         {
           "Id": 2,
-          "References": ["I Cor. 7:17-24", "Eph. 6:5-9"]
+          "References": ["1Cor.7.17-1Cor.7.24", "Eph.6.5-Eph.6.9"]
         },
         {
           "Id": 3,
-          "References": ["Ps. 103:20, 21."]
+          "References": ["Ps.103.20-Ps.103.21"]
         }
       ]
     },
@@ -2384,19 +2384,19 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ps. 104:27-30", "Ps. 145:15, 16", "Matt. 6:25-34"]
+          "References": ["Ps.104.27-Ps.104.30", "Ps.145.15-Ps.145.16", "Matt.6.25-Matt.6.34"]
         },
         {
           "Id": 2,
-          "References": ["Acts 14:17", "Acts 17:25", "James 1:17"]
+          "References": ["Acts.14.17", "Acts.17.25", "Jas.1.17"]
         },
         {
           "Id": 3,
-          "References": ["Deut. 8:3", "Ps. 37:16", "Ps. 127:1, 2", "I Cor. 15:58"]
+          "References": ["Deut.8.3", "Ps.37.16", "Ps.127.1-Ps.127.2", "1Cor.15.58"]
         },
         {
           "Id": 4,
-          "References": ["Ps. 55:22", "62", "146", "Jer. 17:5-8", "Heb. 13:5, 6."]
+          "References": ["Ps.55.22", "Ps.62.11", "Ps.146", "Jer.17.5-Jer.17.8", "Heb.13.5-Heb.13.6"]
         }
       ]
     },
@@ -2408,11 +2408,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ps. 51:1-7", "Ps. 143:2", "Rom. 8:1", "I John 2:1, 2"]
+          "References": ["Ps.51.1-Ps.51.7", "Ps.143.2", "Rom.8.1", "1John.2.1-1John.2.2"]
         },
         {
           "Id": 2,
-          "References": ["Matt. 6:14, 15", "Matt. 18:21-35."]
+          "References": ["Matt.6.14-Matt.6.15", "Matt.18.21-Matt.18.35"]
         }
       ]
     },
@@ -2424,27 +2424,27 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ps. 103:14-16", "John 15:1-5"]
+          "References": ["Ps.103.14-Ps.103.16", "John.15.1-John.15.5"]
         },
         {
           "Id": 2,
-          "References": ["II Cor. 11:14", "Eph. 6:10-13", "I Pet. 5:8"]
+          "References": ["2Cor.11.14", "Eph.6.10-Eph.6.13", "1Pet.5.8"]
         },
         {
           "Id": 3,
-          "References": ["John 15:18-21"]
+          "References": ["John.15.18-John.15.21"]
         },
         {
           "Id": 4,
-          "References": ["Rom. 7:23", "Gal. 5:17"]
+          "References": ["Rom.7.23", "Gal.5.17"]
         },
         {
           "Id": 5,
-          "References": ["Matt. 10:19, 20", "Matt. 26:41", "Mark 13:33", "Rom. 5:3-5"]
+          "References": ["Matt.10.19-Matt.10.20", "Matt.26.41", "Mark.13.33", "Rom.5.3-Rom.5.5"]
         },
         {
           "Id": 6,
-          "References": ["I Cor. 10:13", "I Thess. 3:13", "I Thess. 5:23."]
+          "References": ["1Cor.10.13", "1Thess.3.13", "1Thess.5.23"]
         }
       ]
     },
@@ -2456,11 +2456,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Rom. 10:11-13", "II Pet 2:9"]
+          "References": ["Rom.10.11-Rom.10.13", "2Pet.2.9"]
         },
         {
           "Id": 2,
-          "References": ["Ps. 115:1", "Jer. 33:8, 9", "John 14:13."]
+          "References": ["Ps.115.1", "Jer.33.8-Jer.33.9", "John.14.13"]
         }
       ]
     },
@@ -2472,7 +2472,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Is. 65:24", "II Cor. 1:20", "II Tim. 2:13."]
+          "References": ["Isa.65.24", "2Cor.1.20", "2Tim.2.13"]
         }
       ]
     }

--- a/creeds/keachs_catechism.json
+++ b/creeds/keachs_catechism.json
@@ -24,7 +24,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Isaiah 44:6", "Psalm 8:1", "Psalm 97:9"]
+          "References": ["Isa.44.6", "Ps.8.1", "Ps.97.9"]
         }
       ]
     },
@@ -36,7 +36,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["1 Cor. 10:31", "Psalm 73:25-26"]
+          "References": ["1Cor.10.31", "Ps.73.25-Ps.73.26"]
         }
       ]
     },
@@ -48,7 +48,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Rom. 1:18-20", "Psalm 19:1,2", "2 Tim. 3:15", "1 Cor.  1:21-24", "1 Cor. 2:9,10"]
+          "References": ["Rom.1.18-Rom.1.20", "Ps.19.1-Ps.19.2", "2Tim.3.15", "1Cor.1.21-1Cor.1.24", "1Cor.2.9-1Cor.2.10"]
         }
       ]
     },
@@ -60,7 +60,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["2 Peter 1:21", "2 Timothy 3:16,17", "Isaiah 8:20"]
+          "References": ["2Pet.1.21", "2Tim.3.16-2Tim.3.17", "Isa.8.20"]
         }
       ]
     },
@@ -72,7 +72,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["1 Cor. 2:6,7,13", "Ps. 119:18, 129", "Acts 10:43, 26:22", "Acts 18:28", "Heb 4:12", "Ps. 19:7-9", "Rom.  15:4", "John 16:13,14", "1 John 2:20-27", "2 Cor.  3:14-17"]
+          "References": ["1Cor.2.6-1Cor.2.7,1Cor.2.13", "Ps.119.18,Ps.119.129", "Acts.10.43,Acts.26.22", "Acts.18.28", "Heb.4.12", "Ps.19.7-Ps.19.9", "Rom.15.4", "John.16.13-John.16.14", "1John.2.20-1John.2.27", "2Cor.3.14-2Cor.3.17"]
         }
       ]
     },
@@ -84,7 +84,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["John 5:39", "Luke 16:29", "Acts 8:28-30", "Acts 17:11"]
+          "References": ["John.5.39", "Luke.16.29", "Acts.8.28-Acts.8.30", "Acts.17.11"]
         }
       ]
     },
@@ -96,7 +96,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["2 Tim. 3:16,17", "John 20:31", "Acts 24:14", "1 Cor.  10:11", "Eccles. 12:13"]
+          "References": ["2Tim.3.16-2Tim.3.17", "John.20.31", "Acts.24.14", "1Cor.10.11", "Eccl.12.13"]
         }
       ]
     },
@@ -108,7 +108,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["John 4:24", "Ps. 147:5", "Ps. 90:2", "James 1:17", "Rev.  4:8", "Ps. 89:14", "Exod. 34:6,7", "1 Tim. 1:17"]
+          "References": ["John.4.24", "Ps.147.5", "Ps.90.2", "Jas.1.17", "Rev.4.8", "Ps.89.14", "Exod.34.6-Exod.34.7", "1Tim.1.17"]
         }
       ]
     },
@@ -120,7 +120,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Deut. 6:4", "Jeremiah 10:10"]
+          "References": ["Deut.6.4", "Jer.10.10"]
         }
       ]
     },
@@ -132,7 +132,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["1 Cor. 8:6", "John 10:30", "John 14:9", "Acts 5:3,4", "Matt. 28:19", "2 Cor. 13:14"]
+          "References": ["1Cor.8.6", "John.10.30", "John.14.9", "Acts.5.3-Acts.5.4", "Matt.28.19", "2Cor.13.14"]
         }
       ]
     },
@@ -144,7 +144,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Eph. 1:11", "Rom. 11:36", "Dan. 4:35"]
+          "References": ["Eph.1.11", "Rom.11.36", "Dan.4.35"]
         }
       ]
     },
@@ -156,7 +156,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Gen. 1:1", "Rev. 4:11", "Matt. 6:26", "Acts 14:17"]
+          "References": ["Gen.1.1", "Rev.4.11", "Matt.6.26", "Acts.14.17"]
         }
       ]
     },
@@ -168,7 +168,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Gen. 1:1", "Heb. 11:3", "Ex. 20:11", "Gen. 1:31"]
+          "References": ["Gen.1.1", "Heb.11.3", "Exod.20.11", "Gen.1.31"]
         }
       ]
     },
@@ -180,7 +180,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Gen. 1:27", "Col. 3:10", "Eph. 4:24", "Gen. 1:28"]
+          "References": ["Gen.1.27", "Col.3.10", "Eph.4.24", "Gen.1.28"]
         }
       ]
     },
@@ -192,7 +192,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Neh. 9:6", "Col. 1:17", "Heb. 1:3", "Ps. 103:19", "Matt.  10:29,30"]
+          "References": ["Neh.9.6", "Col.1.17", "Heb.1.3", "Ps.103.19", "Matt.10.29-Matt.10.30"]
         }
       ]
     },
@@ -204,7 +204,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Gen. 2:16,17", "Gal. 3:12", "Rom. 5:12"]
+          "References": ["Gen.2.16-Gen.2.17", "Gal.3.12", "Rom.5.12"]
         }
       ]
     },
@@ -216,7 +216,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Gen. 3:6", "Eccles. 7:29", "Rom. 5:12"]
+          "References": ["Gen.3.6", "Eccl.7.29", "Rom.5.12"]
         }
       ]
     },
@@ -228,7 +228,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["1 John 3:4", "Rom. 5:13"]
+          "References": ["1John.3.4", "Rom.5.13"]
         }
       ]
     },
@@ -240,7 +240,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Gen. 3:6,12,13"]
+          "References": ["Gen.3.6,Gen.3.12-Gen.3.13"]
         }
       ]
     },
@@ -252,7 +252,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["1 Cor. 15:21,22", "Rom. 5:12,18,19"]
+          "References": ["1Cor.15.21-1Cor.15.22", "Rom.5.12,Rom.5.18-Rom.5.19"]
         }
       ]
     },
@@ -264,7 +264,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ps. 51:5", "Rom. 5:18,19", "Is. 64:6"]
+          "References": ["Ps.51.5", "Rom.5.18-Rom.5.19", "Isa.64.6"]
         }
       ]
     },
@@ -276,7 +276,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Rom. 5:19", "Rom. 3:10", "Eph. 2:1", "Is. 53:6", "Ps. 51:5", "Matt. 15:19"]
+          "References": ["Rom.5.19", "Rom.3.10", "Eph.2.1", "Isa.53.6", "Ps.51.5", "Matt.15.19"]
         }
       ]
     },
@@ -288,7 +288,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Gen. 3:8,24", "Eph. 2:3", "Gal. 3:10", "Rom. 6:23", "Matt.  25:41-46", "Ps. 9:17"]
+          "References": ["Gen.3.8,Gen.3.24", "Eph.2.3", "Gal.3.10", "Rom.6.23", "Matt.25.41-Matt.25.46", "Ps.9.17"]
         }
       ]
     },
@@ -300,7 +300,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Eph. 1:3,4", "2 Thess. 2:13", "Rom. 5:21", "Acts 13:8", "Jer. 31:33"]
+          "References": ["Eph.1.3-Eph.1.4", "2Thess.2.13", "Rom.5.21", "Acts.13.8", "Jer.31.33"]
         }
       ]
     },
@@ -312,7 +312,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Gal. 3:13", "1 Tim. 2:5", "John 1:14", "1 Tim. 3:16", "Rom.  9:5", "Col. 2:9"]
+          "References": ["Gal.3.13", "1Tim.2.5", "John.1.14", "1Tim.3.16", "Rom.9.5", "Col.2.9"]
         }
       ]
     },
@@ -324,7 +324,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Heb. 2:14", "Matt. 26:38", "Luke 2:52", "John 12:27", "Luke 1:31,35", "Heb. 4:15", "Heb. 7:26"]
+          "References": ["Heb.2.14", "Matt.26.38", "Luke.2.52", "John.12.27", "Luke.1.31,Luke.1.35", "Heb.4.15", "Heb.7.26"]
         }
       ]
     },
@@ -336,7 +336,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Acts 3:22", "Heb. 5:6", "Ps. 2:6"]
+          "References": ["Acts.3.22", "Heb.5.6", "Ps.2.6"]
         }
       ]
     },
@@ -348,7 +348,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["John 1:18", "John 14:26", "John 15:15"]
+          "References": ["John.1.18", "John.14.26", "John.15.15"]
         }
       ]
     },
@@ -360,7 +360,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["1 Peter 2:24", "Heb. 9:28", "Eph. 5:2", "Heb. 2:17", "Heb. 7:25", "Rom. 8:34"]
+          "References": ["1Pet.2.24", "Heb.9.28", "Eph.5.2", "Heb.2.17", "Heb.7.25", "Rom.8.34"]
         }
       ]
     },
@@ -372,7 +372,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ps. 110:3", "Matt. 2:6", "1 Cor. 15:25"]
+          "References": ["Ps.110.3", "Matt.2.6", "1Cor.15.25"]
         }
       ]
     },
@@ -384,7 +384,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Luke 2:7", "Gal. 4:4", "Is. 53:3", "Luke 22:44", "Matt.  27:46", "Phil. 2:8", "Matt. 12:40", "Mark 15:45,46"]
+          "References": ["Luke.2.7", "Gal.4.4", "Isa.53.3", "Luke.22.44", "Matt.27.46", "Phil.2.8", "Matt.12.40", "Mark.15.45-Mark.15.46"]
         }
       ]
     },
@@ -396,7 +396,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["1 Cor. 15:4", "Acts 1:11", "Mark 16:19", "Acts 17:31"]
+          "References": ["1Cor.15.4", "Acts.1.11", "Mark.16.19", "Acts.17.31"]
         }
       ]
     },
@@ -408,7 +408,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["John 3:5,6", "Titus 3:5,6"]
+          "References": ["John.3.5-John.3.6", "Titus.3.5-Titus.3.6"]
         }
       ]
     },
@@ -420,7 +420,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Eph. 2:8", "Eph. 3:17"]
+          "References": ["Eph.2.8", "Eph.3.17"]
         }
       ]
     },
@@ -432,7 +432,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["2 Tim. 1:9", "John 16:8-11", "Acts 2:37", "Acts 26:18", "Ezekiel 36:26", "John 6:44,45", "1 Cor. 12:3"]
+          "References": ["2Tim.1.9", "John.16.8-John.16.11", "Acts.2.37", "Acts.26.18", "Ezek.36.26", "John.6.44-John.6.45", "1Cor.12.3"]
         }
       ]
     },
@@ -444,7 +444,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Rom. 8:30", "Gal. 3:26", "1 Cor. 6:11", "Rom. 8:31,32", "Eph. 1:5", "1 Cor. 1:30"]
+          "References": ["Rom.8.30", "Gal.3.26", "1Cor.6.11", "Rom.8.31-Rom.8.32", "Eph.1.5", "1Cor.1.30"]
         }
       ]
     },
@@ -456,7 +456,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Rom. 3:24", "Eph. 1:7", "2 Cor. 5:21", "Rom. 5:19", "Phil.  3:9", "Gal. 2:16"]
+          "References": ["Rom.3.24", "Eph.1.7", "2Cor.5.21", "Rom.5.19", "Phil.3.9", "Gal.2.16"]
         }
       ]
     },
@@ -468,7 +468,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["1 John 3:1", "John 1:12", "Rom. 8:16,17"]
+          "References": ["1John.3.1", "John.1.12", "Rom.8.16-Rom.8.17"]
         }
       ]
     },
@@ -480,7 +480,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["2 Thess. 2:13", "Eph. 4:23,24", "Rom. 6:11"]
+          "References": ["2Thess.2.13", "Eph.4.23-Eph.4.24", "Rom.6.11"]
         }
       ]
     },
@@ -492,7 +492,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Rom. 5:1-5", "Rom. 14:17", "Prov. 4:18", "1 Peter 1:5", "1 John 5:13"]
+          "References": ["Rom.5.1-Rom.5.5", "Rom.14.17", "Prov.4.18", "1Pet.1.5", "1John.5.13"]
         }
       ]
     },
@@ -504,7 +504,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Heb. 12:23", "Phil. 1:23", "2 Cor. 5:8", "Luke 23:43", "1 Thess 4:14", "Is. 57:2", "Job 19:26"]
+          "References": ["Heb.12.23", "Phil.1.23", "2Cor.5.8", "Luke.23.43", "1Thess.4.14", "Isa.57.2", "Job.19.26"]
         }
       ]
     },
@@ -516,7 +516,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Phil. 3:20,21", "1 Cor. 15:42,43", "Matt. 10:32", "1 John 3:2", "1 Thess. 4:17"]
+          "References": ["Phil.3.20-Phil.3.21", "1Cor.15.42-1Cor.15.43", "Matt.10.32", "1John.3.2", "1Thess.4.17"]
         }
       ]
     },
@@ -528,7 +528,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Luke 16:22-24", "Ps. 49:14"]
+          "References": ["Luke.16.22-Luke.16.24", "Ps.49.14"]
         }
       ]
     },
@@ -540,7 +540,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Dan. 12:2", "John 5:28,29", "2 Thess. 1:9", "Matt.  25:41"]
+          "References": ["Dan.12.2", "John.5.28-John.5.29", "2Thess.1.9", "Matt.25.41"]
         }
       ]
     },
@@ -552,7 +552,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Micah 6:8", "Eccles. 12:13", "Ps. 119:4", "Luke 10:26-28"]
+          "References": ["Mic.6.8", "Eccl.12.13", "Ps.119.4", "Luke.10.26-Luke.10.28"]
         }
       ]
     },
@@ -564,7 +564,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Rom. 2:14,15", "Rom. 5:13,14"]
+          "References": ["Rom.2.14-Rom.2.15", "Rom.5.13-Rom.5.14"]
         }
       ]
     },
@@ -576,7 +576,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Deut. 10:4", "Matt. 19:17"]
+          "References": ["Deut.10.4", "Matt.19.17"]
         }
       ]
     },
@@ -588,7 +588,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 22:36-40", "Mark 12:28-33"]
+          "References": ["Matt.22.36-Matt.22.40", "Mark.12.28-Mark.12.33"]
         }
       ]
     },
@@ -600,7 +600,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Exodus 20:2"]
+          "References": ["Exod.20.2"]
         }
       ]
     },
@@ -612,7 +612,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Deut 11:1"]
+          "References": ["Deut.11.1"]
         }
       ]
     },
@@ -624,7 +624,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Exodus 20:3"]
+          "References": ["Exod.20.3"]
         }
       ]
     },
@@ -636,7 +636,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Joshua 24:15", "1 Chron. 28:9", "Deut. 26:17", "Ps.  29:2", "Matt. 4:10"]
+          "References": ["Josh.24.15", "1Chr.28.9", "Deut.26.17", "Ps.29.2", "Matt.4.10"]
         }
       ]
     },
@@ -648,7 +648,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Joshua 24:27", "Rom. 1:20,21", "Ps. 14:1", "Rom. 1:25"]
+          "References": ["Josh.24.27", "Rom.1.20-Rom.1.21", "Ps.14.1", "Rom.1.25"]
         }
       ]
     },
@@ -660,7 +660,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Deut.30:17,18", "Ps. 44:20,21", "Ps. 90:8"]
+          "References": ["Deut.30.17-Deut.30.18", "Ps.44.20-Ps.44.21", "Ps.90.8"]
         }
       ]
     },
@@ -672,7 +672,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Exodus 20:4-6"]
+          "References": ["Exod.20.4-Exod.20.6"]
         }
       ]
     },
@@ -684,7 +684,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Deut. 32:46", "Matt. 28:20", "Deut. 12:32"]
+          "References": ["Deut.32.46", "Matt.28.20", "Deut.12.32"]
         }
       ]
     },
@@ -696,7 +696,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Rom. 1:22,23", "Deut. 4:15,16", "Matt. 15:9", "Col.  2:18"]
+          "References": ["Rom.1.22-Rom.1.23", "Deut.4.15-Deut.4.16", "Matt.15.9", "Col.2.18"]
         }
       ]
     },
@@ -708,7 +708,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ps. 45:11", "Ex. 34:14", "1 Cor. 10:22"]
+          "References": ["Ps.45.11", "Exod.34.14", "1Cor.10.22"]
         }
       ]
     },
@@ -720,7 +720,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Exodus 20:7"]
+          "References": ["Exod.20.7"]
         }
       ]
     },
@@ -732,7 +732,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ps.29:2", "Deut. 32:1-4", "Deut.28:58,59", "Ps.111:9", "Matt. 6:9, Eccles. 5:1", "Ps. 138:2, Job 36:24", "Rev.  15:3,4", "Reve 4:8"]
+          "References": ["Ps.29.2", "Deut.32.1-Deut.32.4", "Deut.28.58-Deut.28.59", "Ps.111.9", "Matt.6.9,Eccl.5.1", "Ps.138.2,Job.36.24", "Rev.15.3-Rev.15.4", "Rev.4.8"]
         }
       ]
     },
@@ -744,7 +744,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Malachi 1:6,7", "Lev. 20:3", "Lev. 19:12", "Matt. 5:34-37", "Isa. 52:5"]
+          "References": ["Mal.1.6-Mal.1.7", "Lev.20.3", "Lev.19.12", "Matt.5.34-Matt.5.37", "Isa.52.5"]
         }
       ]
     },
@@ -756,7 +756,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Deut. 28:58,59", "Malachi 2:2"]
+          "References": ["Deut.28.58-Deut.28.59", "Mal.2.2"]
         }
       ]
     },
@@ -768,7 +768,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Exodus 20:8-11"]
+          "References": ["Exod.20.8-Exod.20.11"]
         }
       ]
     },
@@ -780,7 +780,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Lev. 19:30", "Deut. 5:12"]
+          "References": ["Lev.19.30", "Deut.5.12"]
         }
       ]
     },
@@ -792,7 +792,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Gen. 2:3", "John 20:19", "Acts 20:7", "1 Cor. 16:1,2", "Rev. 1:10"]
+          "References": ["Gen.2.3", "John.20.19", "Acts.20.7", "1Cor.16.1-1Cor.16.2", "Rev.1.10"]
         }
       ]
     },
@@ -804,7 +804,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Lev. 23:3", "Isa. 58:13,14", "Isa. 66:23", "Matt.  12:11,12"]
+          "References": ["Lev.23.3", "Isa.58.13-Isa.58.14", "Isa.66.23", "Matt.12.11-Matt.12.12"]
         }
       ]
     },
@@ -816,7 +816,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ezekiel 22:26", "Ezekiel 23:38", "Jer. 17:21", "Neh. 13:15,17", "Acts 20:7"]
+          "References": ["Ezek.22.26", "Ezek.23.38", "Jer.17.21", "Neh.13.15,Neh.13.17", "Acts.20.7"]
         }
       ]
     },
@@ -828,7 +828,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Exodus 34:21", "Exodus 31:16,17", "Gen. 2:2,3"]
+          "References": ["Exod.34.21", "Exod.31.16-Exod.31.17", "Gen.2.2-Gen.2.3"]
         }
       ]
     },
@@ -840,7 +840,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Exodus 20:12"]
+          "References": ["Exod.20.12"]
         }
       ]
     },
@@ -852,7 +852,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Lev. 19:32", "1 Peter 2:17", "Rom. 13:1", "Eph. 5:21,22", "Eph. 6:1,5,9", "Col. 3:19-22", "Rom. 12:10"]
+          "References": ["Lev.19.32", "1Pet.2.17", "Rom.13.1", "Eph.5.21-Eph.5.22", "Eph.6.1,Eph.6.5,Eph.6.9", "Col.3.19-Col.3.22", "Rom.12.10"]
         }
       ]
     },
@@ -864,7 +864,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Prov. 30:17", "Rom. 13:7,8"]
+          "References": ["Prov.30.17", "Rom.13.7-Rom.13.8"]
         }
       ]
     },
@@ -876,7 +876,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Eph. 6:2,3", "Prov. 4:3-6", "Prov. 6:20-22"]
+          "References": ["Eph.6.2-Eph.6.3", "Prov.4.3-Prov.4.6", "Prov.6.20-Prov.6.22"]
         }
       ]
     },
@@ -888,7 +888,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Exodus 20:13"]
+          "References": ["Exod.20.13"]
         }
       ]
     },
@@ -900,7 +900,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Eph. 5:29,30", "Ps. 82:3,4", "Prov. 24:11,12", "Act 16:28"]
+          "References": ["Eph.5.29-Eph.5.30", "Ps.82.3-Ps.82.4", "Prov.24.11-Prov.24.12", "Acts.16.28"]
         }
       ]
     },
@@ -912,7 +912,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Gen. 4:10,11", "Gen. 9:6", "Matt. 5:21-26"]
+          "References": ["Gen.4.10-Gen.4.11", "Gen.9.6", "Matt.5.21-Matt.5.26"]
         }
       ]
     },
@@ -924,7 +924,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Exodus 20:14"]
+          "References": ["Exod.20.14"]
         }
       ]
     },
@@ -936,7 +936,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["1 Cor. 6:18", "1 Cor. 7:2", "2 Tim. 2:22", "Matt. 5:28", "1 Peter 3:2"]
+          "References": ["1Cor.6.18", "1Cor.7.2", "2Tim.2.22", "Matt.5.28", "1Pet.3.2"]
         }
       ]
     },
@@ -948,7 +948,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 5:28-32", "Job 31:1", "Eph. 5:3,4", "Rom. 13:13", "Col. 4:6"]
+          "References": ["Matt.5.28-Matt.5.32", "Job.31.1", "Eph.5.3-Eph.5.4", "Rom.13.13", "Col.4.6"]
         }
       ]
     },
@@ -960,7 +960,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Exodus 20:15"]
+          "References": ["Exod.20.15"]
         }
       ]
     },
@@ -972,7 +972,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Prov. 27:23", "Lev. 25:35", "Deut. 15:10", "Deut. 22:14"]
+          "References": ["Prov.27.23", "Lev.25.35", "Deut.15.10", "Deut.22.14"]
         }
       ]
     },
@@ -984,7 +984,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["1 Tim. 5:8", "Prov. 28:19", "Prov. 23:20,21", "Eph. 4:28"]
+          "References": ["1Tim.5.8", "Prov.28.19", "Prov.23.20-Prov.23.21", "Eph.4.28"]
         }
       ]
     },
@@ -996,7 +996,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Exodus 20:16"]
+          "References": ["Exod.20.16"]
         }
       ]
     },
@@ -1008,7 +1008,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Zech. 8:16", "Acts 25:10", "Eccles. 7:1", "3 John 12", "Prov. 14:5,25"]
+          "References": ["Zech.8.16", "Acts.25.10", "Eccl.7.1", "3John.1.12", "Prov.14.5,Prov.14.25"]
         }
       ]
     },
@@ -1020,7 +1020,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Eph. 4:25", "Ps. 15:3", "2 Cor. 8:20,21"]
+          "References": ["Eph.4.25", "Ps.15.3", "2Cor.8.20-2Cor.8.21"]
         }
       ]
     },
@@ -1032,7 +1032,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Exodus 20:17"]
+          "References": ["Exod.20.17"]
         }
       ]
     },
@@ -1044,7 +1044,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Heb. 13:5", "1 Tim. 6:6", "Rom. 12:15", "1 Cor. 13:4-7", "Lev. 19:18"]
+          "References": ["Heb.13.5", "1Tim.6.6", "Rom.12.15", "1Cor.13.4-1Cor.13.7", "Lev.19.18"]
         }
       ]
     },
@@ -1056,7 +1056,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["1 Cor. 10:10", "James 5:9", "Gal. 5:26", "Col. 3:5"]
+          "References": ["1Cor.10.10", "Jas.5.9", "Gal.5.26", "Col.3.5"]
         }
       ]
     },
@@ -1068,7 +1068,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Eccles. 7:20", "Gen. 6:5", "Gen. 8:21", "1 John 1:8", "James 3:8", "James 3:2", "Rom. 3:23"]
+          "References": ["Eccl.7.20", "Gen.6.5", "Gen.8.21", "1John.1.8", "Jas.3.8", "Jas.3.2", "Rom.3.23"]
         }
       ]
     },
@@ -1080,7 +1080,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ps. 19:7-11", "Rom. 3:20,31", "Rom. 7:7", "Rom. 12:2", "Titus 2:12-14", "Gal. 3:22,24", "1 Tim. 1:8"]
+          "References": ["Ps.19.7-Ps.19.11", "Rom.3.20,Rom.3.31", "Rom.7.7", "Rom.12.2", "Titus.2.12-Titus.2.14", "Gal.3.22,Gal.3.24", "1Tim.1.8"]
         }
       ]
     },
@@ -1092,7 +1092,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ezekiel 8:13", "John 19:11", "1 John 5:16"]
+          "References": ["Ezek.8.13", "John.19.11", "1John.5.16"]
         }
       ]
     },
@@ -1104,7 +1104,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Eph.5:6", "Gal. 3:10", "Prov. 3:33", "Ps. 11:6", "Rev.  21:8"]
+          "References": ["Eph.5.6", "Gal.3.10", "Prov.3.33", "Ps.11.6", "Rev.21.8"]
         }
       ]
     },
@@ -1116,7 +1116,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Acts 20:21", "Acts 16:30,31", "Acts 17:30"]
+          "References": ["Acts.20.21", "Acts.16.30-Acts.16.31", "Acts.17.30"]
         }
       ]
     },
@@ -1128,7 +1128,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Heb. 10:39", "John 1:12", "Phil. 3-9", "Gal. 2:15,16"]
+          "References": ["Heb.10.39", "John.1.12", "Phil.3.9", "Gal.2.15-Gal.2.16"]
         }
       ]
     },
@@ -1140,7 +1140,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Acts 2:37", "Joel 2:13", "Jer. 31:18,19", "2 Cor.  7:10,11", "Rom. 6:18"]
+          "References": ["Acts.2.37", "Joel.2.13", "Jer.31.18-Jer.31.19", "2Cor.7.10-2Cor.7.11", "Rom.6.18"]
         }
       ]
     },
@@ -1152,7 +1152,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Rom. 10:17", "James 1:18", "1 Cor. 3:5", "Acts 14:1", "Acts 2:41,42"]
+          "References": ["Rom.10.17", "Jas.1.18", "1Cor.3.5", "Acts.14.1", "Acts.2.41-Acts.2.42"]
         }
       ]
     },
@@ -1164,7 +1164,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ps. 119:11,18", "1 Thess. 1:6", "1 Peter 2:1,2", "Rom.  1:16", "Ps. 19:7"]
+          "References": ["Ps.119.11,Ps.119.18", "1Thess.1.6", "1Pet.2.1-1Pet.2.2", "Rom.1.16", "Ps.19.7"]
         }
       ]
     },
@@ -1176,7 +1176,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Prov. 8:34", "1 Peter 2:1,2", "1 Tim. 4:13", "Heb.  2:1,3", "Heb. 4:2", "2 Thess. 2:10", "Ps. 119:11", "James 1:21,25"]
+          "References": ["Prov.8.34", "1Pet.2.1-1Pet.2.2", "1Tim.4.13", "Heb.2.1,Heb.2.3", "Heb.4.2", "2Thess.2.10", "Ps.119.11", "Jas.1.21,Jas.1.25"]
         }
       ]
     },
@@ -1188,7 +1188,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["1 Peter 3:21", "1 Cor. 3:6,7", "1 Cor. 12:13"]
+          "References": ["1Pet.3.21", "1Cor.3.6-1Cor.3.7", "1Cor.12.13"]
         }
       ]
     },
@@ -1200,7 +1200,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 28:19", "Acts 22:16", "Matt. 26:26-28", "Rom. 6:4"]
+          "References": ["Matt.28.19", "Acts.22.16", "Matt.26.26-Matt.26.28", "Rom.6.4"]
         }
       ]
     },
@@ -1212,7 +1212,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 28:19", "Rom. 6:3-5", "Col. 2:12", "Gal. 3:27"]
+          "References": ["Matt.28.19", "Rom.6.3-Rom.6.5", "Col.2.12", "Gal.3.27"]
         }
       ]
     },
@@ -1224,7 +1224,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Acts 2:38", "Matt. 3:6", "Mark 16:16", "Acts 8:12,36", "Acts 10:47,48"]
+          "References": ["Acts.2.38", "Matt.3.6", "Mark.16.16", "Acts.8.12,Acts.8.36", "Acts.10.47-Acts.10.48"]
         }
       ]
     },
@@ -1243,7 +1243,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 3:16", "John 3:23", "Acts 8:38,39"]
+          "References": ["Matt.3.16", "John.3.23", "Acts.8.38-Acts.8.39"]
         }
       ]
     },
@@ -1255,7 +1255,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Acts 2:46,47", "Acts 9:26", "1 Peter 2:5", "Heb. 10:25", "Rom. 16:5"]
+          "References": ["Acts.2.46-Acts.2.47", "Acts.9.26", "1Pet.2.5", "Heb.10.25", "Rom.16.5"]
         }
       ]
     },
@@ -1267,7 +1267,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Acts 2:42", "Acts 20:7", "Acts 7:38", "Eph. 4:11,12"]
+          "References": ["Acts.2.42", "Acts.20.7", "Acts.7.38", "Eph.4.11-Eph.4.12"]
         }
       ]
     },
@@ -1279,7 +1279,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Eph. 1:10", "Eph. 1:22,23", "John 10:16", "John 11:52"]
+          "References": ["Eph.1.10", "Eph.1.22-Eph.1.23", "John.10.16", "John.11.52"]
         }
       ]
     },
@@ -1291,7 +1291,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["1 Cor. 11:23-26", "1 Cor. 10:16"]
+          "References": ["1Cor.11.23-1Cor.11.26", "1Cor.10.16"]
         }
       ]
     },
@@ -1303,7 +1303,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["1 Cor. 11:27-31", "1 Cor. 5:8", "2 Cor. 13:5"]
+          "References": ["1Cor.11.27-1Cor.11.31", "1Cor.5.8", "2Cor.13.5"]
         }
       ]
     },
@@ -1315,7 +1315,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["1 John 5:14", "1 John 1:9", "Phil. 4:6", "Ps. 10:17", "Ps. 145:19", "John 14:13,14"]
+          "References": ["1John.5.14", "1John.1.9", "Phil.4.6", "Ps.10.17", "Ps.145.19", "John.14.13-John.14.14"]
         }
       ]
     },
@@ -1327,7 +1327,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 6:9-13", "2 Tim. 3:16,17"]
+          "References": ["Matt.6.9-Matt.6.13", "2Tim.3.16-2Tim.3.17"]
         }
       ]
     },
@@ -1339,7 +1339,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 6:9", "Luke 11:13", "Rom. 8:15", "Acts 12:5", "1 Tim. 2:1-3"]
+          "References": ["Matt.6.9", "Luke.11.13", "Rom.8.15", "Acts.12.5", "1Tim.2.1-1Tim.2.3"]
         }
       ]
     },
@@ -1351,7 +1351,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 6:9", "Ps. 67:1-3", "Rom. 11:36", "Rev. 4:11"]
+          "References": ["Matt.6.9", "Ps.67.1-Ps.67.3", "Rom.11.36", "Rev.4.11"]
         }
       ]
     },
@@ -1363,7 +1363,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 6:10", "Ps. 68:1-18", "Rom. 10:1", "2 Thess. 3:1", "Matt. 9:37,38", "Rev. 22:20"]
+          "References": ["Matt.6.10", "Ps.68.1-Ps.68.18", "Rom.10.1", "2Thess.3.1", "Matt.9.37-Matt.9.38", "Rev.22.20"]
         }
       ]
     },
@@ -1375,7 +1375,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 6:10", "Ps. 103:20,21", "Ps. 25:4,5", "Ps. 119:26"]
+          "References": ["Matt.6.10", "Ps.103.20-Ps.103.21", "Ps.25.4-Ps.25.5", "Ps.119.26"]
         }
       ]
     },
@@ -1387,7 +1387,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 6:11", "Prov. 30:8,9", "1 Tim. 6:6-8", "1 Tim. 4:4,5"]
+          "References": ["Matt.6.11", "Prov.30.8-Prov.30.9", "1Tim.6.6-1Tim.6.8", "1Tim.4.4-1Tim.4.5"]
         }
       ]
     },
@@ -1399,7 +1399,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 6:12", "Ps. 51:1,3,7", "Mark 11:25", "Matt. 18:35"]
+          "References": ["Matt.6.12", "Ps.51.1,Ps.51.3,Ps.51.7", "Mark.11.25", "Matt.18.35"]
         }
       ]
     },
@@ -1411,7 +1411,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 6:13", "Matt. 26:41", "Ps. 19:13", "1 Cor. 10:13", "John 17:15"]
+          "References": ["Matt.6.13", "Matt.26.41", "Ps.19.13", "1Cor.10.13", "John.17.15"]
         }
       ]
     },
@@ -1423,7 +1423,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 6:13", "Dan. 9:18,19", "1 Chron. 29:11-13", "1 Cor. 14:16", "Phil. 4:6", "Rev. 22:20"]
+          "References": ["Matt.6.13", "Dan.9.18-Dan.9.19", "1Chr.29.11-1Chr.29.13", "1Cor.14.16", "Phil.4.6", "Rev.22.20"]
         }
       ]
     }

--- a/creeds/puritan_catechism.json
+++ b/creeds/puritan_catechism.json
@@ -22,11 +22,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["1Co 10:31"]
+          "References": ["1Cor.10.31"]
         },
         {
           "Id": 2,
-          "References": ["Ps 73:25,26"]
+          "References": ["Ps.73.25-Ps.73.26"]
         }
       ]
     },
@@ -38,11 +38,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Eph 2:20", "2Ti 3:16"]
+          "References": ["Eph.2.20", "2Tim.3.16"]
         },
         {
           "Id": 2,
-          "References": ["1Jo 1:3"]
+          "References": ["1John.1.3"]
         }
       ]
     },
@@ -54,7 +54,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["2Ti 1:13", "Ec 12:13"]
+          "References": ["2Tim.1.13", "Eccl.12.13"]
         }
       ]
     },
@@ -66,35 +66,35 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Joh 4:24"]
+          "References": ["John.4.24"]
         },
         {
           "Id": 2,
-          "References": ["Job 11:7"]
+          "References": ["Job.11.7"]
         },
         {
           "Id": 3,
-          "References": ["Ps 90:2", "1Ti 1:17"]
+          "References": ["Ps.90.2", "1Tim.1.17"]
         },
         {
           "Id": 4,
-          "References": ["Jas 1:17"]
+          "References": ["Jas.1.17"]
         },
         {
           "Id": 5,
-          "References": ["Ex 3:14"]
+          "References": ["Exod.3.14"]
         },
         {
           "Id": 6,
-          "References": ["Ps 147:5"]
+          "References": ["Ps.147.5"]
         },
         {
           "Id": 7,
-          "References": ["Re 4:8"]
+          "References": ["Rev.4.8"]
         },
         {
           "Id": 8,
-          "References": ["Ex 34:6,7"]
+          "References": ["Exod.34.6-Exod.34.7"]
         }
       ]
     },
@@ -106,11 +106,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["De 6:4"]
+          "References": ["Deut.6.4"]
         },
         {
           "Id": 2,
-          "References": ["Jer 10:10"]
+          "References": ["Jer.10.10"]
         }
       ]
     },
@@ -122,7 +122,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["1Jo 5:7", "Mt 28:19"]
+          "References": ["1John.5.7", "Matt.28.19"]
         }
       ]
     },
@@ -134,7 +134,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Eph 1:11,12"]
+          "References": ["Eph.1.11-Eph.1.12"]
         }
       ]
     },
@@ -146,11 +146,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Re 4:11"]
+          "References": ["Rev.4.11"]
         },
         {
           "Id": 2,
-          "References": ["Da 4:35"]
+          "References": ["Dan.4.35"]
         }
       ]
     },
@@ -162,19 +162,19 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ge 1:1"]
+          "References": ["Gen.1.1"]
         },
         {
           "Id": 2,
-          "References": ["Heb 11:3"]
+          "References": ["Heb.11.3"]
         },
         {
           "Id": 3,
-          "References": ["Ex 20:11"]
+          "References": ["Exod.20.11"]
         },
         {
           "Id": 4,
-          "References": ["Ge 1:31"]
+          "References": ["Gen.1.31"]
         }
       ]
     },
@@ -186,15 +186,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ge 1:27"]
+          "References": ["Gen.1.27"]
         },
         {
           "Id": 2,
-          "References": ["Col 3:10", "Eph 4:24"]
+          "References": ["Col.3.10", "Eph.4.24"]
         },
         {
           "Id": 3,
-          "References": ["Gen 1:28"]
+          "References": ["Gen.1.28"]
         }
       ]
     },
@@ -206,19 +206,19 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ps 145:17"]
+          "References": ["Ps.145.17"]
         },
         {
           "Id": 2,
-          "References": ["Isa 28:29"]
+          "References": ["Isa.28.29"]
         },
         {
           "Id": 3,
-          "References": ["Heb 1:3"]
+          "References": ["Heb.1.3"]
         },
         {
           "Id": 4,
-          "References": ["Ps 103:19", "Mt 10:29"]
+          "References": ["Ps.103.19", "Matt.10.29"]
         }
       ]
     },
@@ -230,11 +230,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ga 3:12"]
+          "References": ["Gal.3.12"]
         },
         {
           "Id": 2,
-          "References": ["Ge 2:17"]
+          "References": ["Gen.2.17"]
         }
       ]
     },
@@ -246,11 +246,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ec 7:29"]
+          "References": ["Eccl.7.29"]
         },
         {
           "Id": 2,
-          "References": ["Ge 3:6-8"]
+          "References": ["Gen.3.6-Gen.3.8"]
         }
       ]
     },
@@ -262,7 +262,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["1Jo 3:4"]
+          "References": ["1John.3.4"]
         }
       ]
     },
@@ -274,7 +274,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["1Co 15:22", "Ro 5:12"]
+          "References": ["1Cor.15.22", "Rom.5.12"]
         }
       ]
     },
@@ -286,7 +286,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ro 5:18"]
+          "References": ["Rom.5.18"]
         }
       ]
     },
@@ -298,19 +298,19 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ro 5:19"]
+          "References": ["Rom.5.19"]
         },
         {
           "Id": 2,
-          "References": ["Ro 3:10"]
+          "References": ["Rom.3.10"]
         },
         {
           "Id": 3,
-          "References": ["Eph 2:1", "Ps 51:5"]
+          "References": ["Eph.2.1", "Ps.51.5"]
         },
         {
           "Id": 4,
-          "References": ["Mt 15:19"]
+          "References": ["Matt.15.19"]
         }
       ]
     },
@@ -322,15 +322,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ge 3:8,24"]
+          "References": ["Gen.3.8,Gen.3.24"]
         },
         {
           "Id": 2,
-          "References": ["Eph 2:3", "Ga 3:10"]
+          "References": ["Eph.2.3", "Gal.3.10"]
         },
         {
           "Id": 3,
-          "References": ["Ro 6:23", "Mt 25:41"]
+          "References": ["Rom.6.23", "Matt.25.41"]
         }
       ]
     },
@@ -342,11 +342,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["2Th 2:13"]
+          "References": ["2Thess.2.13"]
         },
         {
           "Id": 2,
-          "References": ["Ro 5:21"]
+          "References": ["Rom.5.21"]
         }
       ]
     },
@@ -358,15 +358,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["1Ti 2:5"]
+          "References": ["1Tim.2.5"]
         },
         {
           "Id": 2,
-          "References": ["Joh 1:14"]
+          "References": ["John.1.14"]
         },
         {
           "Id": 3,
-          "References": ["1Ti 3:16", "Col 2:9"]
+          "References": ["1Tim.3.16", "Col.2.9"]
         }
       ]
     },
@@ -378,19 +378,19 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Heb 2:14"]
+          "References": ["Heb.2.14"]
         },
         {
           "Id": 2,
-          "References": ["Mt 26:38", "Heb 4:15"]
+          "References": ["Matt.26.38", "Heb.4.15"]
         },
         {
           "Id": 3,
-          "References": ["Lu 1:31,35"]
+          "References": ["Luke.1.31,Luke.1.35"]
         },
         {
           "Id": 4,
-          "References": ["Heb 7:26"]
+          "References": ["Heb.7.26"]
         }
       ]
     },
@@ -402,15 +402,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ac 3:22"]
+          "References": ["Acts.3.22"]
         },
         {
           "Id": 2,
-          "References": ["Heb 5:6"]
+          "References": ["Heb.5.6"]
         },
         {
           "Id": 3,
-          "References": ["Ps 2:6"]
+          "References": ["Ps.2.6"]
         }
       ]
     },
@@ -422,15 +422,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Joh 1:18"]
+          "References": ["John.1.18"]
         },
         {
           "Id": 2,
-          "References": ["Joh 20:31"]
+          "References": ["John.20.31"]
         },
         {
           "Id": 3,
-          "References": ["Joh 14:26"]
+          "References": ["John.14.26"]
         }
       ]
     },
@@ -442,15 +442,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Heb 9:28"]
+          "References": ["Heb.9.28"]
         },
         {
           "Id": 2,
-          "References": ["Heb 2:17"]
+          "References": ["Heb.2.17"]
         },
         {
           "Id": 3,
-          "References": ["Heb 7:25"]
+          "References": ["Heb.7.25"]
         }
       ]
     },
@@ -462,11 +462,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ps 110:3"]
+          "References": ["Ps.110.3"]
         },
         {
           "Id": 2,
-          "References": ["Mt 2:6", "1Co 15:25"]
+          "References": ["Matt.2.6", "1Cor.15.25"]
         }
       ]
     },
@@ -478,27 +478,27 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Lu 2:7"]
+          "References": ["Luke.2.7"]
         },
         {
           "Id": 2,
-          "References": ["Ga 4:4"]
+          "References": ["Gal.4.4"]
         },
         {
           "Id": 3,
-          "References": ["Isa 53:3"]
+          "References": ["Isa.53.3"]
         },
         {
           "Id": 4,
-          "References": ["Mt 27:46"]
+          "References": ["Matt.27.46"]
         },
         {
           "Id": 5,
-          "References": ["Php 2:8"]
+          "References": ["Phil.2.8"]
         },
         {
           "Id": 6,
-          "References": ["Mt 12:40"]
+          "References": ["Matt.12.40"]
         }
       ]
     },
@@ -510,15 +510,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["1Co 15:4"]
+          "References": ["1Cor.15.4"]
         },
         {
           "Id": 2,
-          "References": ["Mr 16:19"]
+          "References": ["Mark.16.19"]
         },
         {
           "Id": 3,
-          "References": ["Ac 17:31"]
+          "References": ["Acts.17.31"]
         }
       ]
     },
@@ -530,11 +530,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Joh 1:12"]
+          "References": ["John.1.12"]
         },
         {
           "Id": 2,
-          "References": ["Tit 3:5,6"]
+          "References": ["Titus.3.5-Titus.3.6"]
         }
       ]
     },
@@ -546,11 +546,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Eph 2:8"]
+          "References": ["Eph.2.8"]
         },
         {
           "Id": 2,
-          "References": ["Eph 3:17"]
+          "References": ["Eph.3.17"]
         }
       ]
     },
@@ -562,23 +562,23 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["2Ti 1:9"]
+          "References": ["2Tim.1.9"]
         },
         {
           "Id": 2,
-          "References": ["Ac 2:37"]
+          "References": ["Acts.2.37"]
         },
         {
           "Id": 3,
-          "References": ["Ac 26:18"]
+          "References": ["Acts.26.18"]
         },
         {
           "Id": 4,
-          "References": ["Eze 36:26"]
+          "References": ["Ezek.36.26"]
         },
         {
           "Id": 5,
-          "References": ["Joh 6:44,45"]
+          "References": ["John.6.44-John.6.45"]
         }
       ]
     },
@@ -590,15 +590,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ro 8:30"]
+          "References": ["Rom.8.30"]
         },
         {
           "Id": 2,
-          "References": ["Eph 1:5"]
+          "References": ["Eph.1.5"]
         },
         {
           "Id": 3,
-          "References": ["1Co 1:30"]
+          "References": ["1Cor.1.30"]
         }
       ]
     },
@@ -610,19 +610,19 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ro 3:24", "Eph 1:7"]
+          "References": ["Rom.3.24", "Eph.1.7"]
         },
         {
           "Id": 2,
-          "References": ["2Co 5:21"]
+          "References": ["2Cor.5.21"]
         },
         {
           "Id": 3,
-          "References": ["Ro 5:19"]
+          "References": ["Rom.5.19"]
         },
         {
           "Id": 4,
-          "References": ["Ga 2:16", "Php 3:9"]
+          "References": ["Gal.2.16", "Phil.3.9"]
         }
       ]
     },
@@ -634,11 +634,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["1Jo 3:1"]
+          "References": ["1John.3.1"]
         },
         {
           "Id": 2,
-          "References": ["Joh 1:12", "Ro 8:17"]
+          "References": ["John.1.12", "Rom.8.17"]
         }
       ]
     },
@@ -650,15 +650,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["2Th 2:13"]
+          "References": ["2Thess.2.13"]
         },
         {
           "Id": 2,
-          "References": ["Eph 4:24"]
+          "References": ["Eph.4.24"]
         },
         {
           "Id": 3,
-          "References": ["Ro 6:11"]
+          "References": ["Rom.6.11"]
         }
       ]
     },
@@ -670,15 +670,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ro 5:1,2,5"]
+          "References": ["Rom.5.1-Rom.5.2,Rom.5.5"]
         },
         {
           "Id": 2,
-          "References": ["Ro 14:17"]
+          "References": ["Rom.14.17"]
         },
         {
           "Id": 3,
-          "References": ["Pr 4:18", "1Jo 5:13", "1Pe 1:5"]
+          "References": ["Prov.4.18", "1John.5.13", "1Pet.1.5"]
         }
       ]
     },
@@ -690,23 +690,23 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Heb 12:23"]
+          "References": ["Heb.12.23"]
         },
         {
           "Id": 2,
-          "References": ["Php 1:23", "2Co 5:8", "Lu 23:43"]
+          "References": ["Phil.1.23", "2Cor.5.8", "Luke.23.43"]
         },
         {
           "Id": 3,
-          "References": ["1Th 4:14"]
+          "References": ["1Thess.4.14"]
         },
         {
           "Id": 4,
-          "References": ["Isa 57:2"]
+          "References": ["Isa.57.2"]
         },
         {
           "Id": 5,
-          "References": ["Job 19:26"]
+          "References": ["Job.19.26"]
         }
       ]
     },
@@ -718,19 +718,19 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["1Co 15:43"]
+          "References": ["1Cor.15.43"]
         },
         {
           "Id": 2,
-          "References": ["Mt 10:32"]
+          "References": ["Matt.10.32"]
         },
         {
           "Id": 3,
-          "References": ["1Jo 3:2"]
+          "References": ["1John.3.2"]
         },
         {
           "Id": 4,
-          "References": ["1Th 4:17"]
+          "References": ["1Thess.4.17"]
         }
       ]
     },
@@ -742,11 +742,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Lu 16:22-24"]
+          "References": ["Luke.16.22-Luke.16.24"]
         },
         {
           "Id": 2,
-          "References": ["Ps 49:14"]
+          "References": ["Ps.49.14"]
         }
       ]
     },
@@ -758,7 +758,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Da 12:2", "Joh 5:28,29", "2Th 1:9", "Mt 25:41"]
+          "References": ["Dan.12.2", "John.5.28-John.5.29", "2Thess.1.9", "Matt.25.41"]
         }
       ]
     },
@@ -770,7 +770,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["De 10:4", "Mt 19:17"]
+          "References": ["Deut.10.4", "Matt.19.17"]
         }
       ]
     },
@@ -782,7 +782,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Mt 22:37-40"]
+          "References": ["Matt.22.37-Matt.22.40"]
         }
       ]
     },
@@ -799,15 +799,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["1Ch 28:9"]
+          "References": ["1Chr.28.9"]
         },
         {
           "Id": 2,
-          "References": ["De 26:17"]
+          "References": ["Deut.26.17"]
         },
         {
           "Id": 3,
-          "References": ["Mt 4:10"]
+          "References": ["Matt.4.10"]
         }
       ]
     },
@@ -824,11 +824,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["De 32:46", "Mt 28:20"]
+          "References": ["Deut.32.46", "Matt.28.20"]
         },
         {
           "Id": 2,
-          "References": ["De 12:32"]
+          "References": ["Deut.12.32"]
         }
       ]
     },
@@ -840,11 +840,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["De 4:15,16"]
+          "References": ["Deut.4.15-Deut.4.16"]
         },
         {
           "Id": 2,
-          "References": ["Col 2:18"]
+          "References": ["Col.2.18"]
         }
       ]
     },
@@ -861,23 +861,23 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ps 29:2"]
+          "References": ["Ps.29.2"]
         },
         {
           "Id": 2,
-          "References": ["Re 15:3,4"]
+          "References": ["Rev.15.3-Rev.15.4"]
         },
         {
           "Id": 3,
-          "References": ["Ec 5:1"]
+          "References": ["Eccl.5.1"]
         },
         {
           "Id": 4,
-          "References": ["Ps 138:2"]
+          "References": ["Ps.138.2"]
         },
         {
           "Id": 5,
-          "References": ["Job 36:24", "De 28:58,59"]
+          "References": ["Job.36.24", "Deut.28.58-Deut.28.59"]
         }
       ]
     },
@@ -894,7 +894,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Le 19:30", "De 5:12"]
+          "References": ["Lev.19.30", "Deut.5.12"]
         }
       ]
     },
@@ -906,15 +906,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Le 23:3"]
+          "References": ["Lev.23.3"]
         },
         {
           "Id": 2,
-          "References": ["Ps 92:1,2", "Isa 58:13,14"]
+          "References": ["Ps.92.1-Ps.92.2", "Isa.58.13-Isa.58.14"]
         },
         {
           "Id": 3,
-          "References": ["Mt 12:11,12"]
+          "References": ["Matt.12.11-Matt.12.12"]
         }
       ]
     },
@@ -931,15 +931,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Eph 5:21,22", "Eph 6:1,5 Ro 13:1"]
+          "References": ["Eph.5.21-Eph.5.22", "Eph.6.1,Eph.6.5,Rom.13.1"]
         },
         {
           "Id": 2,
-          "References": ["Eph 6:9"]
+          "References": ["Eph.6.9"]
         },
         {
           "Id": 3,
-          "References": ["Ro 12:10"]
+          "References": ["Rom.12.10"]
         }
       ]
     },
@@ -951,7 +951,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Eph 6:2,3"]
+          "References": ["Eph.6.2-Eph.6.3"]
         }
       ]
     },
@@ -968,15 +968,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ac 16:28"]
+          "References": ["Acts.16.28"]
         },
         {
           "Id": 2,
-          "References": ["Ge 9:6"]
+          "References": ["Gen.9.6"]
         },
         {
           "Id": 3,
-          "References": ["Pr 24:11,12"]
+          "References": ["Prov.24.11-Prov.24.12"]
         }
       ]
     },
@@ -993,15 +993,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Mt 5:28", "Col 4:6"]
+          "References": ["Matt.5.28", "Col.4.6"]
         },
         {
           "Id": 2,
-          "References": ["Eph 5:4", "2Ti 2:22"]
+          "References": ["Eph.5.4", "2Tim.2.22"]
         },
         {
           "Id": 3,
-          "References": ["Eph 5:3"]
+          "References": ["Eph.5.3"]
         }
       ]
     },
@@ -1018,11 +1018,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["1Ti 5:8", "Pr 28:19", "Pr 21:6"]
+          "References": ["1Tim.5.8", "Prov.28.19", "Prov.21.6"]
         },
         {
           "Id": 2,
-          "References": ["Eph 4:28"]
+          "References": ["Eph.4.28"]
         }
       ]
     },
@@ -1039,19 +1039,19 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Zec 8:16"]
+          "References": ["Zech.8.16"]
         },
         {
           "Id": 2,
-          "References": ["1Pe 3:16", "Ac 25:10"]
+          "References": ["1Pet.3.16", "Acts.25.10"]
         },
         {
           "Id": 3,
-          "References": ["3Jo 1:12"]
+          "References": ["3John.1.12"]
         },
         {
           "Id": 4,
-          "References": ["Pr 14:5,25"]
+          "References": ["Prov.14.5,Prov.14.25"]
         }
       ]
     },
@@ -1068,15 +1068,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["1Co 10:10"]
+          "References": ["1Cor.10.10"]
         },
         {
           "Id": 2,
-          "References": ["Ga 5:26"]
+          "References": ["Gal.5.26"]
         },
         {
           "Id": 3,
-          "References": ["Col 3:5"]
+          "References": ["Col.3.5"]
         }
       ]
     },
@@ -1088,19 +1088,19 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ec 7:20"]
+          "References": ["Eccl.7.20"]
         },
         {
           "Id": 2,
-          "References": ["Ge 8:21"]
+          "References": ["Gen.8.21"]
         },
         {
           "Id": 3,
-          "References": ["Jas 3:8"]
+          "References": ["Jas.3.8"]
         },
         {
           "Id": 4,
-          "References": ["Jas 3:2"]
+          "References": ["Jas.3.2"]
         }
       ]
     },
@@ -1112,7 +1112,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Joh 19:11", "1Jo 5:15"]
+          "References": ["John.19.11", "1John.5.15"]
         }
       ]
     },
@@ -1124,7 +1124,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Eph 5:6", "Ps 11:6"]
+          "References": ["Eph.5.6", "Ps.11.6"]
         }
       ]
     },
@@ -1136,11 +1136,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Joh 3:16"]
+          "References": ["John.3.16"]
         },
         {
           "Id": 2,
-          "References": ["Ac 20:21"]
+          "References": ["Acts.20.21"]
         }
       ]
     },
@@ -1152,19 +1152,19 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Heb 10:39"]
+          "References": ["Heb.10.39"]
         },
         {
           "Id": 2,
-          "References": ["Joh 1:12"]
+          "References": ["John.1.12"]
         },
         {
           "Id": 3,
-          "References": ["Php 3:9"]
+          "References": ["Phil.3.9"]
         },
         {
           "Id": 4,
-          "References": ["Isa 33:22"]
+          "References": ["Isa.33.22"]
         }
       ]
     },
@@ -1176,23 +1176,23 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ac 11:18"]
+          "References": ["Acts.11.18"]
         },
         {
           "Id": 2,
-          "References": ["Ac 2:37"]
+          "References": ["Acts.2.37"]
         },
         {
           "Id": 3,
-          "References": ["Joe 2:13"]
+          "References": ["Joel.2.13"]
         },
         {
           "Id": 4,
-          "References": ["Jer 31:18,19"]
+          "References": ["Jer.31.18-Jer.31.19"]
         },
         {
           "Id": 5,
-          "References": ["Ps 119:59"]
+          "References": ["Ps.119.59"]
         }
       ]
     },
@@ -1204,7 +1204,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ac 2:41,42", "Jas 1:18"]
+          "References": ["Acts.2.41-Acts.2.42", "Jas.1.18"]
         }
       ]
     },
@@ -1216,15 +1216,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ps 19:7"]
+          "References": ["Ps.19.7"]
         },
         {
           "Id": 2,
-          "References": ["1Th 1:6"]
+          "References": ["1Thess.1.6"]
         },
         {
           "Id": 3,
-          "References": ["Ro 1:16"]
+          "References": ["Rom.1.16"]
         }
       ]
     },
@@ -1236,27 +1236,27 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Pr 8:34", "1Pe 2:1,2"]
+          "References": ["Prov.8.34", "1Pet.2.1-1Pet.2.2"]
         },
         {
           "Id": 2,
-          "References": ["Ps 119:18"]
+          "References": ["Ps.119.18"]
         },
         {
           "Id": 3,
-          "References": ["Heb 4:2"]
+          "References": ["Heb.4.2"]
         },
         {
           "Id": 4,
-          "References": ["2Th 2:10"]
+          "References": ["2Thess.2.10"]
         },
         {
           "Id": 5,
-          "References": ["Ps 119:11"]
+          "References": ["Ps.119.11"]
         },
         {
           "Id": 6,
-          "References": ["Jas 1:25"]
+          "References": ["Jas.1.25"]
         }
       ]
     },
@@ -1268,15 +1268,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["1Co 3:7", "1Pe 3:21"]
+          "References": ["1Cor.3.7", "1Pet.3.21"]
         },
         {
           "Id": 2,
-          "References": ["1Co 3:6"]
+          "References": ["1Cor.3.6"]
         },
         {
           "Id": 3,
-          "References": ["1Co 12:13"]
+          "References": ["1Cor.12.13"]
         }
       ]
     },
@@ -1288,23 +1288,23 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Mt 28:19"]
+          "References": ["Matt.28.19"]
         },
         {
           "Id": 2,
-          "References": ["Ro 6:3", "Col 2:12"]
+          "References": ["Rom.6.3", "Col.2.12"]
         },
         {
           "Id": 3,
-          "References": ["Ga 3:27"]
+          "References": ["Gal.3.27"]
         },
         {
           "Id": 4,
-          "References": ["Mr 1:4", "Ac 22:16"]
+          "References": ["Mark.1.4", "Acts.22.16"]
         },
         {
           "Id": 5,
-          "References": ["Ro 6:4,5"]
+          "References": ["Rom.6.4-Rom.6.5"]
         }
       ]
     },
@@ -1316,7 +1316,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ac 2:38", "Mt 3:6", "Mr 16:16", "Ac 8:12,36,37 10:47,48"]
+          "References": ["Acts.2.38", "Matt.3.6", "Mark.16.16", "Acts.8.12,Acts.8.36-Acts.8.37,Acts.10.47-Acts.10.48"]
         }
       ]
     },
@@ -1328,7 +1328,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ex 23:13", "Pr 30:6"]
+          "References": ["Exod.23.13", "Prov.30.6"]
         }
       ]
     },
@@ -1340,15 +1340,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Mt 3:16", "Joh 3:23"]
+          "References": ["Matt.3.16", "John.3.23"]
         },
         {
           "Id": 2,
-          "References": ["Mt 28:19,20"]
+          "References": ["Matt.28.19-Matt.28.20"]
         },
         {
           "Id": 3,
-          "References": ["Joh 4:1,2", "Ac 8:38,39"]
+          "References": ["John.4.1-John.4.2", "Acts.8.38-Acts.8.39"]
         }
       ]
     },
@@ -1360,11 +1360,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ac 2:47", "Ac 9:26", "1Pe 2:5"]
+          "References": ["Acts.2.47", "Acts.9.26", "1Pet.2.5"]
         },
         {
           "Id": 2,
-          "References": ["Lu 1:6"]
+          "References": ["Luke.1.6"]
         }
       ]
     },
@@ -1376,11 +1376,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["1Co 11:23-26"]
+          "References": ["1Cor.11.23-1Cor.11.26"]
         },
         {
           "Id": 2,
-          "References": ["1Co 10:16"]
+          "References": ["1Cor.10.16"]
         }
       ]
     },
@@ -1392,27 +1392,27 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["1Co 11:28,29"]
+          "References": ["1Cor.11.28-1Cor.11.29"]
         },
         {
           "Id": 2,
-          "References": ["2Co 13:5"]
+          "References": ["2Cor.13.5"]
         },
         {
           "Id": 3,
-          "References": ["1Co 11:31"]
+          "References": ["1Cor.11.31"]
         },
         {
           "Id": 4,
-          "References": ["1Co 11:18-20"]
+          "References": ["1Cor.11.18-1Cor.11.20"]
         },
         {
           "Id": 5,
-          "References": ["1Co 5:8"]
+          "References": ["1Cor.5.8"]
         },
         {
           "Id": 6,
-          "References": ["1Co 11:27-29"]
+          "References": ["1Cor.11.27-1Cor.11.29"]
         }
       ]
     },
@@ -1424,7 +1424,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ac 1:11", "1Th 4:16"]
+          "References": ["Acts.1.11", "1Thess.4.16"]
         }
       ]
     }

--- a/creeds/shema_yisrael.json
+++ b/creeds/shema_yisrael.json
@@ -23,7 +23,7 @@
     "Proofs": [
       {
         "Id": 1,
-        "References": ["Deut. 6:4-5"]
+        "References": ["Deut.6.4-Deut.6.5"]
       }
     ]
   }

--- a/creeds/westminster_larger_catechism.json
+++ b/creeds/westminster_larger_catechism.json
@@ -22,11 +22,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Rom. 11:36", "I Cor. 10:31"]
+          "References": ["Rom.11.36", "1Cor.10.31"]
         },
         {
           "Id": 2,
-          "References": ["Psa. 73:24-28"]
+          "References": ["Ps.73.24-Ps.73.28"]
         }
       ]
     },
@@ -38,11 +38,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Rom. 1:19-20", "Psa. 19:1-3", "Acts 17:28"]
+          "References": ["Rom.1.19-Rom.1.20", "Ps.19.1-Ps.19.3", "Acts.17.28"]
         },
         {
           "Id": 2,
-          "References": ["I Cor. 2:9-10", "II Tim. 3:15-17", "Isa 59:21"]
+          "References": ["1Cor.2.9-1Cor.2.10", "2Tim.3.15-2Tim.3.17", "Isa.59.21"]
         }
       ]
     },
@@ -54,11 +54,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["II Tim. 3:16", "II Peter 1:19-21"]
+          "References": ["2Tim.3.16", "2Pet.1.19-2Pet.1.21"]
         },
         {
           "Id": 2,
-          "References": ["Eph. 2:20", "Rev. 22:18-19", "Isa. 8:20", "Luke 16:29, 31", "Gal. 1:8-9", "II Tim. 3:15-16"]
+          "References": ["Eph.2.20", "Rev.22.18-Rev.22.19", "Isa.8.20", "Luke.16.29,Luke.16.31", "Gal.1.8-Gal.1.9", "2Tim.3.15-2Tim.3.16"]
         }
       ]
     },
@@ -70,27 +70,27 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Hosea 8:12", "1 Cor. 2:6-7, 13", "Psa. 119:18, 129"]
+          "References": ["Hos.8.12", "1Cor.2.6-1Cor.2.7,1Cor.2.13", "Ps.119.18,Ps.119.129"]
         },
         {
           "Id": 2,
-          "References": ["Psa. 12:6", "Psa. 119:140"]
+          "References": ["Ps.12.6", "Ps.119.140"]
         },
         {
           "Id": 3,
-          "References": ["Acts 10:43", "Acts 26:22"]
+          "References": ["Acts.10.43", "Acts.26.22"]
         },
         {
           "Id": 4,
-          "References": ["Rom. 3:19, 27"]
+          "References": ["Rom.3.19,Rom.3.27"]
         },
         {
           "Id": 5,
-          "References": ["Acts 23:28", "Heb. 4:12", "James 1:18", "Psa. 19:7-9", "Rom. 15:4", "Acts 20:32"]
+          "References": ["Acts.23.28", "Heb.4.12", "Jas.1.18", "Ps.19.7-Ps.19.9", "Rom.15.4", "Acts.20.32"]
         },
         {
           "Id": 6,
-          "References": ["John 16:13-14", "John 20:31", "1 John 2:20, 27"]
+          "References": ["John.16.13-John.16.14", "John.20.31", "1John.2.20,1John.2.27"]
         }
       ]
     },
@@ -102,7 +102,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["2 Tim. 1:13"]
+          "References": ["2Tim.1.13"]
         }
       ]
     },
@@ -114,19 +114,19 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Heb. 11:6"]
+          "References": ["Heb.11.6"]
         },
         {
           "Id": 2,
-          "References": ["1 John 5:7"]
+          "References": ["1John.5.7"]
         },
         {
           "Id": 3,
-          "References": ["Acts 15:14-15, 18"]
+          "References": ["Acts.15.14-Acts.15.15,Acts.15.18"]
         },
         {
           "Id": 4,
-          "References": ["Acts 4:27-28"]
+          "References": ["Acts.4.27-Acts.4.28"]
         }
       ]
     },
@@ -138,67 +138,67 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["John 4:24"]
+          "References": ["John.4.24"]
         },
         {
           "Id": 2,
-          "References": ["Exod. 3:14", "Job 11:7-9"]
+          "References": ["Exod.3.14", "Job.11.7-Job.11.9"]
         },
         {
           "Id": 3,
-          "References": ["Acts 7:2"]
+          "References": ["Acts.7.2"]
         },
         {
           "Id": 4,
-          "References": ["I Tim. 6:15"]
+          "References": ["1Tim.6.1"]
         },
         {
           "Id": 5,
-          "References": ["Matt. 5:48"]
+          "References": ["Matt.5.48"]
         },
         {
           "Id": 6,
-          "References": ["Gen. 17:1"]
+          "References": ["Gen.17.1"]
         },
         {
           "Id": 7,
-          "References": ["Psa. 90:2"]
+          "References": ["Ps.90.2"]
         },
         {
           "Id": 8,
-          "References": ["Mal. 3:6", "James 1:17"]
+          "References": ["Mal.3.6", "Jas.1.17"]
         },
         {
           "Id": 9,
-          "References": ["I Kings 8:27"]
+          "References": ["1Kgs.8.27"]
         },
         {
           "Id": 10,
-          "References": ["Psa. 139:1-13"]
+          "References": ["Ps.139.1-Ps.139.13"]
         },
         {
           "Id": 11,
-          "References": ["Rev. 4:8"]
+          "References": ["Rev.4.8"]
         },
         {
           "Id": 12,
-          "References": ["Heb. 4:13", "Psa 147:5"]
+          "References": ["Heb.4.13", "Ps.147.5"]
         },
         {
           "Id": 13,
-          "References": ["Rom. 16:27"]
+          "References": ["Rom.16.27"]
         },
         {
           "Id": 14,
-          "References": ["Isa. 6:3", "Rev. 15:4"]
+          "References": ["Isa.6.3", "Rev.15.4"]
         },
         {
           "Id": 15,
-          "References": ["Deut. 32:4"]
+          "References": ["Deut.32.4"]
         },
         {
           "Id": 16,
-          "References": ["Exod. 34:6"]
+          "References": ["Exod.34.6"]
         }
       ]
     },
@@ -210,7 +210,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Deut. 6:4", "I Cor. 8:4, 6", "Jer. 10:10"]
+          "References": ["Deut.6.4", "1Cor.8.4,1Cor.8.6", "Jer.10.10"]
         }
       ]
     },
@@ -222,7 +222,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["I John 5:7", "Matt. 3:16-17", "Matt. 28:19", "II Cor. 13:14", "John 10:30"]
+          "References": ["1John.5.7", "Matt.3.16-Matt.3.17", "Matt.28.19", "2Cor.13.14", "John.10.30"]
         }
       ]
     },
@@ -234,15 +234,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Heb. 1:5-6, 8"]
+          "References": ["Heb.1.5-Heb.1.6,Heb.1.8"]
         },
         {
           "Id": 2,
-          "References": ["John 1:14, 18"]
+          "References": ["John.1.14,John.1.18"]
         },
         {
           "Id": 3,
-          "References": ["John 15:26", "Gal. 4:6"]
+          "References": ["John.15.26", "Gal.4.6"]
         }
       ]
     },
@@ -254,19 +254,19 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Isa. 6:3, 5, 8", "John 12:41", "Acts 5:3-4", "Acts 28:25", "I John 5:20"]
+          "References": ["Isa.6.3,Isa.6.5,Isa.6.8", "John.12.41", "Acts.5.3-Acts.5.4", "Acts.28.25", "1John.5.20"]
         },
         {
           "Id": 2,
-          "References": ["John 1:1", "John 2:24-25", "Isa. 9:6", "I Cor. 2:10-11"]
+          "References": ["John.1.1", "John.2.24-John.2.25", "Isa.9.6", "1Cor.2.10-1Cor.2.11"]
         },
         {
           "Id": 3,
-          "References": ["Col. 1:16", "Gen. 1:2"]
+          "References": ["Col.1.16", "Gen.1.2"]
         },
         {
           "Id": 4,
-          "References": ["Matt. 28:19", "II Cor. 13:14"]
+          "References": ["Matt.28.19", "2Cor.13.14"]
         }
       ]
     },
@@ -278,11 +278,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Eph. 1:11", "Rom. 9:14-15, 18", "Rom. 11:33"]
+          "References": ["Eph.1.11", "Rom.9.14-Rom.9.15,Rom.9.18", "Rom.11.33"]
         },
         {
           "Id": 2,
-          "References": ["Eph. 1:4, 11", "Rom. 9:22-23", "Psa. 33:11"]
+          "References": ["Eph.1.4,Eph.1.11", "Rom.9.22-Rom.9.23", "Ps.33.11"]
         }
       ]
     },
@@ -294,15 +294,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["I Tim. 5:21"]
+          "References": ["1Tim.5.21"]
         },
         {
           "Id": 2,
-          "References": ["Eph. 1:4-6", "II Thess. 2:13-14"]
+          "References": ["Eph.1.4-Eph.1.6", "2Thess.2.13-2Thess.2.14"]
         },
         {
           "Id": 3,
-          "References": ["Rom. 9:17-18, 21-22", "Matt. 11:25-26", "II Tim. 2:20", "Jude 1:4", "I Peter 2:8"]
+          "References": ["Rom.9.17-Rom.9.18,Rom.9.21-Rom.9.22", "Matt.11.25-Matt.11.26", "2Tim.2.20", "Jude.1.4", "1Pet.2.8"]
         }
       ]
     },
@@ -314,7 +314,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Eph. 1:11"]
+          "References": ["Eph.1.11"]
         }
       ]
     },
@@ -326,7 +326,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Gen. ch. 1", "Heb. 11:8", "Prov 16:4"]
+          "References": ["Gen.1", "Heb.11.8", "Prov.16.4"]
         }
       ]
     },
@@ -338,35 +338,35 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Col. 1:16"]
+          "References": ["Col.1.16"]
         },
         {
           "Id": 2,
-          "References": ["Psa. 104:4"]
+          "References": ["Ps.104.4"]
         },
         {
           "Id": 3,
-          "References": ["Matt. 22:30"]
+          "References": ["Matt.22.30"]
         },
         {
           "Id": 4,
-          "References": ["Matt. 25:31"]
+          "References": ["Matt.25.31"]
         },
         {
           "Id": 5,
-          "References": ["II Sam. 14:17", "Matt. 24:36"]
+          "References": ["2Sam.14.17", "Matt.24.36"]
         },
         {
           "Id": 6,
-          "References": ["II Thess. 1:7"]
+          "References": ["2Thess.1.7"]
         },
         {
           "Id": 7,
-          "References": ["Psa. 103:20-21"]
+          "References": ["Ps.103.20-Ps.103.21"]
         },
         {
           "Id": 8,
-          "References": ["II Peter 2:4"]
+          "References": ["2Pet.2.4"]
         }
       ]
     },
@@ -378,47 +378,47 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Gen. 1:27"]
+          "References": ["Gen.1.27"]
         },
         {
           "Id": 2,
-          "References": ["Gen. 2:7"]
+          "References": ["Gen.2.7"]
         },
         {
           "Id": 3,
-          "References": ["Gen. 2:22"]
+          "References": ["Gen.2.22"]
         },
         {
           "Id": 4,
-          "References": ["Gen. 2:7", "Job 35:11", "Eccl. 12:7", "Matt. 10:28", "Luke 23:43"]
+          "References": ["Gen.2.7", "Job.35.11", "Eccl.12.7", "Matt.10.28", "Luke.23.43"]
         },
         {
           "Id": 5,
-          "References": ["Gen. 1:27"]
+          "References": ["Gen.1.27"]
         },
         {
           "Id": 6,
-          "References": ["Col. 3:10"]
+          "References": ["Col.3.10"]
         },
         {
           "Id": 7,
-          "References": ["Eph. 4:24"]
+          "References": ["Eph.4.24"]
         },
         {
           "Id": 8,
-          "References": ["Rom. 2:14-15"]
+          "References": ["Rom.2.14-Rom.2.15"]
         },
         {
           "Id": 9,
-          "References": ["Eccl. 7:29"]
+          "References": ["Eccl.7.29"]
         },
         {
           "Id": 10,
-          "References": ["Gen. 1:28"]
+          "References": ["Gen.1.28"]
         },
         {
           "Id": 11,
-          "References": ["Gen. 3:6", "Eccl. 7:29"]
+          "References": ["Gen.3.6", "Eccl.7.29"]
         }
       ]
     },
@@ -430,27 +430,27 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Psa. 145:17"]
+          "References": ["Ps.145.17"]
         },
         {
           "Id": 2,
-          "References": ["Psa. 104:24", "Isa. 28:29"]
+          "References": ["Ps.104.24", "Isa.28.29"]
         },
         {
           "Id": 3,
-          "References": ["Heb. 1:8"]
+          "References": ["Heb.1.8"]
         },
         {
           "Id": 4,
-          "References": ["Psa. 103:19"]
+          "References": ["Ps.103.19"]
         },
         {
           "Id": 5,
-          "References": ["Matt. 10:29-31", "Gen. 45:7"]
+          "References": ["Matt.10.29-Matt.10.31", "Gen.45.7"]
         },
         {
           "Id": 6,
-          "References": ["Rom. 11:36", "Isa. 43:14"]
+          "References": ["Rom.11.36", "Isa.43.14"]
         }
       ]
     },
@@ -462,23 +462,23 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Jude 1:6", "II Peter 2:4", "Heb. 2:16", "John 8:44"]
+          "References": ["Jude.1.6", "2Pet.2.4", "Heb.2.16", "John.8.44"]
         },
         {
           "Id": 2,
-          "References": ["Job 1:12", "Matt. 8:31"]
+          "References": ["Job.1.12", "Matt.8.31"]
         },
         {
           "Id": 3,
-          "References": ["I Tim. 5:21", "Mark 8:38", "Heb. 12:22"]
+          "References": ["1Tim.5.21", "Mark.8.38", "Heb.12.22"]
         },
         {
           "Id": 4,
-          "References": ["Psa. 104:4"]
+          "References": ["Ps.104.4"]
         },
         {
           "Id": 5,
-          "References": ["II Kings 19:35", "Heb. 1:14"]
+          "References": ["2Kgs.19.35", "Heb.1.14"]
         }
       ]
     },
@@ -490,35 +490,35 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Gen. 2:8, 15-16"]
+          "References": ["Gen.2.8,Gen.2.15-Gen.2.16"]
         },
         {
           "Id": 2,
-          "References": ["Gen. 1:28"]
+          "References": ["Gen.1.28"]
         },
         {
           "Id": 3,
-          "References": ["Gen. 2:18"]
+          "References": ["Gen.2.18"]
         },
         {
           "Id": 4,
-          "References": ["Gen. 1:26-29", "Gen. 3:8"]
+          "References": ["Gen.1.26-Gen.1.29", "Gen.3.8"]
         },
         {
           "Id": 5,
-          "References": ["Gen. 2:3"]
+          "References": ["Gen.2.3"]
         },
         {
           "Id": 6,
-          "References": ["Gal. 3:12", "Rom. 10:5"]
+          "References": ["Gal.3.12", "Rom.10.5"]
         },
         {
           "Id": 7,
-          "References": ["Gen. 2:9"]
+          "References": ["Gen.2.9"]
         },
         {
           "Id": 8,
-          "References": ["Gen. 2:17"]
+          "References": ["Gen.2.17"]
         }
       ]
     },
@@ -530,7 +530,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Gen. 3:6-8, 13", "Eccl. 7:29", "II Cor. 11:3"]
+          "References": ["Gen.3.6-Gen.3.8,Gen.3.13", "Eccl.7.29", "2Cor.11.3"]
         }
       ]
     },
@@ -542,11 +542,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Acts 17:26"]
+          "References": ["Acts.17.26"]
         },
         {
           "Id": 2,
-          "References": ["Gen. 2:16-17", "Rom. 5:12-20", "I Cor. 15:21-22"]
+          "References": ["Gen.2.16-Gen.2.17", "Rom.5.12-Rom.5.20", "1Cor.15.21-1Cor.15.22"]
         }
       ]
     },
@@ -558,7 +558,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Rom. 3:23", "Rom. 5:12"]
+          "References": ["Rom.3.23", "Rom.5.12"]
         }
       ]
     },
@@ -570,7 +570,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["I John 3:4", "Gal. 3:10, 12"]
+          "References": ["1John.3.4", "Gal.3.10,Gal.3.12"]
         }
       ]
     },
@@ -582,15 +582,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Rom. 5:12, 19"]
+          "References": ["Rom.5.12,Rom.5.19"]
         },
         {
           "Id": 2,
-          "References": ["Rom. 3:10-19", "Rom. 5:6", "Rom. 8:7-8", "Eph. 2:1-3", "Gen. 6:5"]
+          "References": ["Rom.3.10-Rom.3.19", "Rom.5.6", "Rom.8.7-Rom.8.8", "Eph.2.1-Eph.2.3", "Gen.6.5"]
         },
         {
           "Id": 3,
-          "References": ["James 1:14-15", "Matt. 15:19"]
+          "References": ["Jas.1.14-Jas.1.15", "Matt.15.19"]
         }
       ]
     },
@@ -602,7 +602,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Psa. 51:5", "Job 14:4", "Job 15:14", "John 3:6"]
+          "References": ["Ps.51.5", "Job.14.4", "Job.15.14", "John.3.6"]
         }
       ]
     },
@@ -614,19 +614,19 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Gen. 3:8, 10, 24"]
+          "References": ["Gen.3.8,Gen.3.10,Gen.3.24"]
         },
         {
           "Id": 2,
-          "References": ["Eph. 2:2-3"]
+          "References": ["Eph.2.2-Eph.2.3"]
         },
         {
           "Id": 3,
-          "References": ["II Tim. 2:26"]
+          "References": ["2Tim.2.26"]
         },
         {
           "Id": 4,
-          "References": ["Gen. 2:17", "Lam. 3:39", "Rom. 6:23", "Matt. 25:41, 46, Jude 1:7"]
+          "References": ["Gen.2.17", "Lam.3.39", "Rom.6.23", "Matt.25.41,Matt.25.46,Jude.1.7"]
         }
       ]
     },
@@ -638,39 +638,39 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Eph. 4:18"]
+          "References": ["Eph.4.18"]
         },
         {
           "Id": 2,
-          "References": ["Rom. 1:28"]
+          "References": ["Rom.1.28"]
         },
         {
           "Id": 3,
-          "References": ["II Thess. 2:11"]
+          "References": ["2Thess.2.11"]
         },
         {
           "Id": 4,
-          "References": ["Rom. 2:5"]
+          "References": ["Rom.2.5"]
         },
         {
           "Id": 5,
-          "References": ["Isa. 33:14", "Gen. 4:13", "Matt. 27:4"]
+          "References": ["Isa.33.14", "Gen.4.13", "Matt.27.4"]
         },
         {
           "Id": 6,
-          "References": ["Rom. 1:26"]
+          "References": ["Rom.1.26"]
         },
         {
           "Id": 7,
-          "References": ["Gen. 3:17"]
+          "References": ["Gen.3.17"]
         },
         {
           "Id": 8,
-          "References": ["Deut. 28:15-18"]
+          "References": ["Deut.28.15-Deut.28.18"]
         },
         {
           "Id": 9,
-          "References": ["Rom. 6:21, 23"]
+          "References": ["Rom.6.21,Rom.6.23"]
         }
       ]
     },
@@ -682,7 +682,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["II Thess. 1:9", "Mark 9:43-44, 46, 48", "Luke 16:24"]
+          "References": ["2Thess.1.9", "Mark.9.43-Mark.9.44,Mark.9.46,Mark.9.48", "Luke.16.24"]
         }
       ]
     },
@@ -694,15 +694,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["I Thess. 5:9"]
+          "References": ["1Thess.5.9"]
         },
         {
           "Id": 2,
-          "References": ["Gal. 3:10, 12"]
+          "References": ["Gal.3.10,Gal.3.12"]
         },
         {
           "Id": 3,
-          "References": ["Titus 3:4-7", "Gal. 3:21", "Rom. 3:20-22"]
+          "References": ["Titus.3.4-Titus.3.7", "Gal.3.21", "Rom.3.20-Rom.3.22"]
         }
       ]
     },
@@ -714,7 +714,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Gal. 3:16", "Rom. 5:15-21", "Isa. 53:10-11"]
+          "References": ["Gal.3.16", "Rom.5.15-Rom.5.21", "Isa.53.10-Isa.53.11"]
         }
       ]
     },
@@ -726,35 +726,35 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Gen. 3:15", "Isa. 42:6", "John 6:27"]
+          "References": ["Gen.3.15", "Isa.42.6", "John.6.27"]
         },
         {
           "Id": 2,
-          "References": ["I John 5:11-12"]
+          "References": ["1John.5.11-1John.5.12"]
         },
         {
           "Id": 3,
-          "References": ["John 1:12", "John 3:16"]
+          "References": ["John.1.12", "John.3.16"]
         },
         {
           "Id": 4,
-          "References": ["Prov. 1:23"]
+          "References": ["Prov.1.23"]
         },
         {
           "Id": 5,
-          "References": ["II Cor. 4:13"]
+          "References": ["2Cor.4.13"]
         },
         {
           "Id": 6,
-          "References": ["Gal. 5:22-23"]
+          "References": ["Gal.5.22-Gal.5.23"]
         },
         {
           "Id": 7,
-          "References": ["Ezek. 36:27"]
+          "References": ["Ezek.36.27"]
         },
         {
           "Id": 8,
-          "References": ["James 2:18, 22"]
+          "References": ["Jas.2.18,Jas.2.22"]
         }
       ]
     },
@@ -766,7 +766,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["II Cor. 3:6-9"]
+          "References": ["2Cor.3.6-2Cor.3.9"]
         }
       ]
     },
@@ -778,31 +778,31 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Rom. 15:8"]
+          "References": ["Rom.15.8"]
         },
         {
           "Id": 2,
-          "References": ["Acts 3:20, 24"]
+          "References": ["Acts.3.20,Acts.3.24"]
         },
         {
           "Id": 3,
-          "References": ["Heb. 10:1"]
+          "References": ["Heb.10.1"]
         },
         {
           "Id": 4,
-          "References": ["Rom. 4:11"]
+          "References": ["Rom.4.11"]
         },
         {
           "Id": 5,
-          "References": ["I Cor. 5:7"]
+          "References": ["1Cor.5.7"]
         },
         {
           "Id": 6,
-          "References": ["Heb. ch. 8-10", "Heb. 11:13"]
+          "References": ["Heb.8-Heb.10", "Heb.11.13"]
         },
         {
           "Id": 7,
-          "References": ["Gal. 3:7-9, 14"]
+          "References": ["Gal.3.7-Gal.3.9,Gal.3.14"]
         }
       ]
     },
@@ -814,19 +814,19 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Mark 16:15"]
+          "References": ["Mark.16.15"]
         },
         {
           "Id": 2,
-          "References": ["Matt. 28:19-20"]
+          "References": ["Matt.28.19-Matt.28.20"]
         },
         {
           "Id": 3,
-          "References": ["I Cor. 11:23-25"]
+          "References": ["1Cor.11.23-1Cor.11.25"]
         },
         {
           "Id": 4,
-          "References": ["II Cor. 3:6-9", "Heb. 8:6, 10-11", "Matt. 28:19"]
+          "References": ["2Cor.3.6-2Cor.3.9", "Heb.8.6,Heb.8.10-Heb.8.11", "Matt.28.19"]
         }
       ]
     },
@@ -838,19 +838,19 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["I Tim. 2:5"]
+          "References": ["1Tim.2.5"]
         },
         {
           "Id": 2,
-          "References": ["John 1:1, 14", "John 10:30", "Phil. 2:6"]
+          "References": ["John.1.1,John.1.14", "John.10.30", "Phil.2.6"]
         },
         {
           "Id": 3,
-          "References": ["Gal. 4:4"]
+          "References": ["Gal.4.4"]
         },
         {
           "Id": 4,
-          "References": ["Luke 1:35", "Rom. 9:5", "Col. 2:9", "Heb. 7:24-25"]
+          "References": ["Luke.1.35", "Rom.9.5", "Col.2.9", "Heb.7.24-Heb.7.25"]
         }
       ]
     },
@@ -862,15 +862,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["John 1:14", "Matt. 26:38"]
+          "References": ["John.1.14", "Matt.26.38"]
         },
         {
           "Id": 2,
-          "References": ["Luke 1:27, 31, 35, 42", "Gal. 4:4"]
+          "References": ["Luke.1.27,Luke.1.31,Luke.1.35,Luke.1.42", "Gal.4.4"]
         },
         {
           "Id": 3,
-          "References": ["Heb. 4:15", "Heb. 7:26"]
+          "References": ["Heb.4.15", "Heb.7.26"]
         }
       ]
     },
@@ -882,35 +882,35 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Acts. 2:24-25", "Rom. 1:4", "Rom. 4:25", "Heb. 9:14"]
+          "References": ["Acts.2.24-Acts.2.25", "Rom.1.4", "Rom.4.25", "Heb.9.14"]
         },
         {
           "Id": 2,
-          "References": ["Acts 20:28", "Heb. 7:25-28", "Heb. 9:14"]
+          "References": ["Acts.20.28", "Heb.7.25-Heb.7.28", "Heb.9.14"]
         },
         {
           "Id": 3,
-          "References": ["Rom. 3:24-26"]
+          "References": ["Rom.3.24-Rom.3.26"]
         },
         {
           "Id": 4,
-          "References": ["Eph. 1:6", "Matt. 3:17"]
+          "References": ["Eph.1.6", "Matt.3.17"]
         },
         {
           "Id": 5,
-          "References": ["Titus. 2:13-14"]
+          "References": ["Titus.2.13-Titus.2.14"]
         },
         {
           "Id": 6,
-          "References": ["Gal. 4:6"]
+          "References": ["Gal.4.6"]
         },
         {
           "Id": 7,
-          "References": ["Luke 1:68-69, 71, 74"]
+          "References": ["Luke.1.68-Luke.1.69,Luke.1.71,Luke.1.74"]
         },
         {
           "Id": 8,
-          "References": ["Heb. 5:8-9", "Heb. 9:11-15"]
+          "References": ["Heb.5.8-Heb.5.9", "Heb.9.11-Heb.9.15"]
         }
       ]
     },
@@ -922,27 +922,27 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Heb. 2:16"]
+          "References": ["Heb.2.16"]
         },
         {
           "Id": 2,
-          "References": ["Gal. 4:4"]
+          "References": ["Gal.4.4"]
         },
         {
           "Id": 3,
-          "References": ["Heb. 2:14", "Heb. 7:24-25"]
+          "References": ["Heb.2.14", "Heb.7.24-Heb.7.25"]
         },
         {
           "Id": 4,
-          "References": ["Heb. 4:15"]
+          "References": ["Heb.4.15"]
         },
         {
           "Id": 5,
-          "References": ["Gal. 4:5"]
+          "References": ["Gal.4.5"]
         },
         {
           "Id": 6,
-          "References": ["Heb. 4:16"]
+          "References": ["Heb.4.16"]
         }
       ]
     },
@@ -954,11 +954,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 1:21, 23", "Matt. 3:17", "Heb. 9:14"]
+          "References": ["Matt.1.21,Matt.1.23", "Matt.3.17", "Heb.9.14"]
         },
         {
           "Id": 2,
-          "References": ["I Peter 2:6"]
+          "References": ["1Pet.2.6"]
         }
       ]
     },
@@ -970,7 +970,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 1:21"]
+          "References": ["Matt.1.21"]
         }
       ]
     },
@@ -982,23 +982,23 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["John 3:34", "Psa. 45:7"]
+          "References": ["John.3.34", "Ps.45.7"]
         },
         {
           "Id": 2,
-          "References": ["John 6:27", "Matt. 28:18-20"]
+          "References": ["John.6.27", "Matt.28.18-Matt.28.20"]
         },
         {
           "Id": 3,
-          "References": ["Acts 3:21-22", "Luke 4:18, 21"]
+          "References": ["Acts.3.21-Acts.3.22", "Luke.4.18,Luke.4.21"]
         },
         {
           "Id": 4,
-          "References": ["Heb. 4:14-15", "Heb. 5:5-7"]
+          "References": ["Heb.4.14-Heb.4.15", "Heb.5.5-Heb.5.7"]
         },
         {
           "Id": 5,
-          "References": ["Psa. 2:6", "Matt. 21:5", "Isa. 9:6-7", "Phil. 2:8-11"]
+          "References": ["Ps.2.6", "Matt.21.5", "Isa.9.6-Isa.9.7", "Phil.2.8-Phil.2.11"]
         }
       ]
     },
@@ -1010,23 +1010,23 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["John 1:18"]
+          "References": ["John.1.18"]
         },
         {
           "Id": 2,
-          "References": ["I Peter 1:10-12"]
+          "References": ["1Pet.1.10-1Pet.1.12"]
         },
         {
           "Id": 3,
-          "References": ["Heb. 1:1-2"]
+          "References": ["Heb.1.1-Heb.1.2"]
         },
         {
           "Id": 4,
-          "References": ["John 15:15"]
+          "References": ["John.15.15"]
         },
         {
           "Id": 5,
-          "References": ["Acts 20:32", "Eph. 4:11-13", "John 20:31"]
+          "References": ["Acts.20.32", "Eph.4.11-Eph.4.13", "John.20.31"]
         }
       ]
     },
@@ -1038,15 +1038,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Heb. 9:14, 28"]
+          "References": ["Heb.9.14,Heb.9.28"]
         },
         {
           "Id": 2,
-          "References": ["Heb. 2:17"]
+          "References": ["Heb.2.17"]
         },
         {
           "Id": 3,
-          "References": ["Heb. 7:25"]
+          "References": ["Heb.7.25"]
         }
       ]
     },
@@ -1058,51 +1058,51 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Acts 15:14-16", "Isa. 4:4-5", "Gen. 49:10", "Psa. 110:3"]
+          "References": ["Acts.15.14-Acts.15.16", "Isa.4.4-Isa.4.5", "Gen.49.10", "Ps.110.3"]
         },
         {
           "Id": 2,
-          "References": ["Eph. 4:11-12", "I Cor. 12:28"]
+          "References": ["Eph.4.11-Eph.4.12", "1Cor.12.28"]
         },
         {
           "Id": 3,
-          "References": ["Isa. 33:22"]
+          "References": ["Isa.33.22"]
         },
         {
           "Id": 4,
-          "References": ["Matt. 18:17-18", "I Cor. 5:4-5"]
+          "References": ["Matt.18.17-Matt.18.18", "1Cor.5.4-1Cor.5.5"]
         },
         {
           "Id": 5,
-          "References": ["Acts 5:31"]
+          "References": ["Acts.5.31"]
         },
         {
           "Id": 6,
-          "References": ["Rev. 2:10", "Rev. 22:12"]
+          "References": ["Rev.2.10", "Rev.22.12"]
         },
         {
           "Id": 7,
-          "References": ["Rev. 3:19"]
+          "References": ["Rev.3.19"]
         },
         {
           "Id": 8,
-          "References": ["Isa. 63:9"]
+          "References": ["Isa.63.9"]
         },
         {
           "Id": 9,
-          "References": ["I Cor. 15:25", "Psa. 110:1-2"]
+          "References": ["1Cor.15.25", "Ps.110.1-Ps.110.2"]
         },
         {
           "Id": 10,
-          "References": ["Rom. 14:10-11"]
+          "References": ["Rom.14.10-Rom.14.11"]
         },
         {
           "Id": 11,
-          "References": ["Rom. 8:28"]
+          "References": ["Rom.8.28"]
         },
         {
           "Id": 12,
-          "References": ["II Thess. 1:8-9", "Psa. 2:8-9"]
+          "References": ["2Thess.1.8-2Thess.1.9", "Ps.2.8-Ps.2.9"]
         }
       ]
     },
@@ -1114,7 +1114,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Phil. 2:6-8", "Luke 1:31", "II Cor. 8:9", "Acts 2:24"]
+          "References": ["Phil.2.6-Phil.2.8", "Luke.1.31", "2Cor.8.9", "Acts.2.24"]
         }
       ]
     },
@@ -1126,7 +1126,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["John 1:14, 18", "Gal. 4:4", "Luke 2:7"]
+          "References": ["John.1.14,John.1.18", "Gal.4.4", "Luke.2.7"]
         }
       ]
     },
@@ -1138,23 +1138,23 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Gal. 4:4"]
+          "References": ["Gal.4.4"]
         },
         {
           "Id": 2,
-          "References": ["Matt. 5:17", "Rom. 5:19"]
+          "References": ["Matt.5.17", "Rom.5.19"]
         },
         {
           "Id": 3,
-          "References": ["Psa. 22:6", "Heb. 12:2-3"]
+          "References": ["Ps.22.6", "Heb.12.2-Heb.12.3"]
         },
         {
           "Id": 4,
-          "References": ["Matt. 4:1-12", "Luke 4:13"]
+          "References": ["Matt.4.1-Matt.4.12", "Luke.4.13"]
         },
         {
           "Id": 5,
-          "References": ["Heb. 2:17-18", "Heb. 4:15", "Isa. 52:13-14"]
+          "References": ["Heb.2.17-Heb.2.18", "Heb.4.15", "Isa.52.13-Isa.52.14"]
         }
       ]
     },
@@ -1166,31 +1166,31 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 27:4"]
+          "References": ["Matt.27.4"]
         },
         {
           "Id": 2,
-          "References": ["Matt. 26:56"]
+          "References": ["Matt.26.56"]
         },
         {
           "Id": 3,
-          "References": ["Isa. 53:2-3"]
+          "References": ["Isa.53.2-Isa.53.3"]
         },
         {
           "Id": 4,
-          "References": ["Matt. 27:26-50", "John 19:34"]
+          "References": ["Matt.27.26-Matt.27.50", "John.19.34"]
         },
         {
           "Id": 5,
-          "References": ["Luke 22:44", "Matt. 27:46"]
+          "References": ["Luke.22.44", "Matt.27.46"]
         },
         {
           "Id": 6,
-          "References": ["Isa. 53:10"]
+          "References": ["Isa.53.10"]
         },
         {
           "Id": 7,
-          "References": ["Phil. 2:8", "Heb. 12:2", "Gal. 3:13"]
+          "References": ["Phil.2.8", "Heb.12.2", "Gal.3.13"]
         }
       ]
     },
@@ -1202,11 +1202,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["I Cor. 15:3-4"]
+          "References": ["1Cor.15.3-1Cor.15.4"]
         },
         {
           "Id": 2,
-          "References": ["Psa. 16:10", "Acts 2:24-27, 31", "Rom. 6:9", "Matt. 12:40"]
+          "References": ["Ps.16.10", "Acts.2.24-Acts.2.27,Acts.2.31", "Rom.6.9", "Matt.12.40"]
         }
       ]
     },
@@ -1218,19 +1218,19 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["I Cor. 15:4"]
+          "References": ["1Cor.15.4"]
         },
         {
           "Id": 2,
-          "References": ["Mark 16:19"]
+          "References": ["Mark.16.19"]
         },
         {
           "Id": 3,
-          "References": ["Eph. 1:20"]
+          "References": ["Eph.1.20"]
         },
         {
           "Id": 4,
-          "References": ["Acts 1:11", "Acts 17:31"]
+          "References": ["Acts.1.11", "Acts.17.31"]
         }
       ]
     },
@@ -1242,59 +1242,59 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Acts 2:24, 27"]
+          "References": ["Acts.2.24,Acts.2.27"]
         },
         {
           "Id": 2,
-          "References": ["Luke 24:39"]
+          "References": ["Luke.24.39"]
         },
         {
           "Id": 3,
-          "References": ["Rom. 6:9", "Rev. 1:18"]
+          "References": ["Rom.6.9", "Rev.1.18"]
         },
         {
           "Id": 4,
-          "References": ["John 10:18"]
+          "References": ["John.10.18"]
         },
         {
           "Id": 5,
-          "References": ["Rom. 1:4"]
+          "References": ["Rom.1.4"]
         },
         {
           "Id": 6,
-          "References": ["Rom. 8:34"]
+          "References": ["Rom.8.34"]
         },
         {
           "Id": 7,
-          "References": ["Heb. 2:14"]
+          "References": ["Heb.2.14"]
         },
         {
           "Id": 8,
-          "References": ["Rom. 14:9"]
+          "References": ["Rom.14.9"]
         },
         {
           "Id": 9,
-          "References": ["I Cor. 15:21-22"]
+          "References": ["1Cor.15.21-1Cor.15.22"]
         },
         {
           "Id": 10,
-          "References": ["Eph. 1:20, 22-23", "Col. 1:18"]
+          "References": ["Eph.1.20,Eph.1.22-Eph.1.23", "Col.1.18"]
         },
         {
           "Id": 11,
-          "References": ["Rom. 4:25"]
+          "References": ["Rom.4.25"]
         },
         {
           "Id": 12,
-          "References": ["Eph. 2:1, 5-6", "Col. 2:12"]
+          "References": ["Eph.2.1,Eph.2.5-Eph.2.6", "Col.2.12"]
         },
         {
           "Id": 13,
-          "References": ["I Cor. 15:25-27"]
+          "References": ["1Cor.15.25-1Cor.15.27"]
         },
         {
           "Id": 14,
-          "References": ["I Cor. 15:20"]
+          "References": ["1Cor.15.20"]
         }
       ]
     },
@@ -1306,35 +1306,35 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Acts 1:2-3"]
+          "References": ["Acts.1.2-Acts.1.3"]
         },
         {
           "Id": 2,
-          "References": ["Matt. 28:19-20"]
+          "References": ["Matt.28.19-Matt.28.20"]
         },
         {
           "Id": 3,
-          "References": ["Heb. 6:20"]
+          "References": ["Heb.6.20"]
         },
         {
           "Id": 4,
-          "References": ["Eph. 4:8"]
+          "References": ["Eph.4.8"]
         },
         {
           "Id": 5,
-          "References": ["Acts 1:9-11", "Eph. 4:10", "Psa. 68:18"]
+          "References": ["Acts.1.9-Acts.1.11", "Eph.4.10", "Ps.68.18"]
         },
         {
           "Id": 6,
-          "References": ["Col. 3:1-2"]
+          "References": ["Col.3.1-Col.3.2"]
         },
         {
           "Id": 7,
-          "References": ["John 14:3"]
+          "References": ["John.14.3"]
         },
         {
           "Id": 8,
-          "References": ["Acts 3:21"]
+          "References": ["Acts.3.21"]
         }
       ]
     },
@@ -1346,27 +1346,27 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Phil. 2:9"]
+          "References": ["Phil.2.9"]
         },
         {
           "Id": 2,
-          "References": ["Acts 2:28", "Psa. 16:11"]
+          "References": ["Acts.2.28", "Ps.16.11"]
         },
         {
           "Id": 3,
-          "References": ["John 17:5"]
+          "References": ["John.17.5"]
         },
         {
           "Id": 4,
-          "References": ["Eph. 1:22", "I Peter 3:22"]
+          "References": ["Eph.1.22", "1Pet.3.22"]
         },
         {
           "Id": 5,
-          "References": ["Eph. 4:10-12", "Psa. 110:1"]
+          "References": ["Eph.4.10-Eph.4.12", "Ps.110.1"]
         },
         {
           "Id": 6,
-          "References": ["Rom. 8:34"]
+          "References": ["Rom.8.34"]
         }
       ]
     },
@@ -1378,35 +1378,35 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Heb. 9:12, 24"]
+          "References": ["Heb.9.12,Heb.9.24"]
         },
         {
           "Id": 2,
-          "References": ["Heb. 1:3"]
+          "References": ["Heb.1.3"]
         },
         {
           "Id": 3,
-          "References": ["John 3:16", "John 17:9, 20, 24"]
+          "References": ["John.3.16", "John.17.9,John.17.20,John.17.24"]
         },
         {
           "Id": 4,
-          "References": ["Rom. 8:33-34"]
+          "References": ["Rom.8.33-Rom.8.34"]
         },
         {
           "Id": 5,
-          "References": ["Rom. 5:1-2", "I John 2:1-2"]
+          "References": ["Rom.5.1-Rom.5.2", "1John.2.1-1John.2.2"]
         },
         {
           "Id": 6,
-          "References": ["Heb. 4:16"]
+          "References": ["Heb.4.16"]
         },
         {
           "Id": 7,
-          "References": ["Eph. 1:6"]
+          "References": ["Eph.1.6"]
         },
         {
           "Id": 8,
-          "References": ["I Peter 2:5"]
+          "References": ["1Pet.2.5"]
         }
       ]
     },
@@ -1418,23 +1418,23 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Acts 3:14-15"]
+          "References": ["Acts.3.14-Acts.3.15"]
         },
         {
           "Id": 2,
-          "References": ["Matt. 14:30"]
+          "References": ["Matt.14.30"]
         },
         {
           "Id": 3,
-          "References": ["Luke 9:26", "Matt. 25:31"]
+          "References": ["Luke.9.26", "Matt.25.31"]
         },
         {
           "Id": 4,
-          "References": ["I Thess. 4:16"]
+          "References": ["1Thess.4.16"]
         },
         {
           "Id": 5,
-          "References": ["Acts 17:31"]
+          "References": ["Acts.17.31"]
         }
       ]
     },
@@ -1446,11 +1446,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Heb. 9:12"]
+          "References": ["Heb.9.12"]
         },
         {
           "Id": 2,
-          "References": ["II Cor. 1:20"]
+          "References": ["2Cor.1.20"]
         }
       ]
     },
@@ -1462,11 +1462,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["John 1:11-12"]
+          "References": ["John.1.11-John.1.12"]
         },
         {
           "Id": 2,
-          "References": ["Titus 3:5-6"]
+          "References": ["Titus.3.5-Titus.3.6"]
         }
       ]
     },
@@ -1478,11 +1478,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Eph. 1:13-14", "John 6:37, 39", "John 10:15-16"]
+          "References": ["Eph.1.13-Eph.1.14", "John.6.37,John.6.39", "John.10.15-John.10.16"]
         },
         {
           "Id": 2,
-          "References": ["Eph. 2:8", "II Cor. 4:13"]
+          "References": ["Eph.2.8", "2Cor.4.13"]
         }
       ]
     },
@@ -1494,31 +1494,31 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Rom. 10:14"]
+          "References": ["Rom.10.14"]
         },
         {
           "Id": 2,
-          "References": ["II Thess. 1:8-9", "Eph. 2:12", "John 1:10-12"]
+          "References": ["2Thess.1.8-2Thess.1.9", "Eph.2.12", "John.1.10-John.1.12"]
         },
         {
           "Id": 3,
-          "References": ["John 8:24", "Mark 16:16"]
+          "References": ["John.8.24", "Mark.16.16"]
         },
         {
           "Id": 4,
-          "References": ["I Cor. 1:20-24"]
+          "References": ["1Cor.1.20-1Cor.1.24"]
         },
         {
           "Id": 5,
-          "References": ["John 4:22", "Rom. 9:31-32", "Phil 3:4-9"]
+          "References": ["John.4.22", "Rom.9.31-Rom.9.32", "Phil.3.4-Phil.3.9"]
         },
         {
           "Id": 6,
-          "References": ["Acts 4:12"]
+          "References": ["Acts.4.12"]
         },
         {
           "Id": 7,
-          "References": ["Eph. 5:23"]
+          "References": ["Eph.5.23"]
         }
       ]
     },
@@ -1530,7 +1530,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["John 12:38-40", "Rom. 9:6", "Rom. 11:7", "Matt. 7:21", "Matt. 22:14"]
+          "References": ["John.12.38-John.12.40", "Rom.9.6", "Rom.11.7", "Matt.7.21", "Matt.22.14"]
         }
       ]
     },
@@ -1542,11 +1542,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["I Cor. 1:2", "I Cor. 12:13", "Rom. 15:9-12", "Rev. 7:9", "Psa. 2:8", "Psa. 22:27-31", "Psa. 45:17", "Matt. 28:19-20", "Isa. 59:21"]
+          "References": ["1Cor.1.2", "1Cor.12.13", "Rom.15.9-Rom.15.12", "Rev.7.9", "Ps.2.8", "Ps.22.27-Ps.22.31", "Ps.45.17", "Matt.28.19-Matt.28.20", "Isa.59.21"]
         },
         {
           "Id": 2,
-          "References": ["I Cor. 7:14", "Acts 2:39", "Rom. 11:16", "Gen. 17:7"]
+          "References": ["1Cor.7.14", "Acts.2.39", "Rom.11.16", "Gen.17.7"]
         }
       ]
     },
@@ -1558,23 +1558,23 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Isa. 4:5-6", "I Tim. 4:10"]
+          "References": ["Isa.4.5-Isa.4.6", "1Tim.4.10"]
         },
         {
           "Id": 2,
-          "References": ["Psa. 115:1-2, 9", "Isa. 31:4-5", "Zech. 12:2-4, 8-9"]
+          "References": ["Ps.115.1-Ps.115.2,Ps.115.9", "Isa.31.4-Isa.31.5", "Zech.12.2-Zech.12.4,Zech.12.8-Zech.12.9"]
         },
         {
           "Id": 3,
-          "References": ["Acts 2:39, 42"]
+          "References": ["Acts.2.39,Acts.2.42"]
         },
         {
           "Id": 4,
-          "References": ["Psa. 147:19-20", "Rom. 9:4", "Eph. 4:11-12", "Mark 16:15-16"]
+          "References": ["Ps.147.19-Ps.147.20", "Rom.9.4", "Eph.4.11-Eph.4.12", "Mark.16.15-Mark.16.16"]
         },
         {
           "Id": 5,
-          "References": ["John 6:37"]
+          "References": ["John.6.37"]
         }
       ]
     },
@@ -1586,7 +1586,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Eph. 1:20, 22-23", "John 10:16, 11:52"]
+          "References": ["Eph.1.20,Eph.1.22-Eph.1.23", "John.10.16,John.11.52"]
         }
       ]
     },
@@ -1598,7 +1598,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["John 17:21, 24", "Eph. 2:5-6"]
+          "References": ["John.17.21,John.17.24", "Eph.2.5-Eph.2.6"]
         }
       ]
     },
@@ -1610,15 +1610,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Eph. 1:22", "Eph. 2:6-8"]
+          "References": ["Eph.1.22", "Eph.2.6-Eph.2.8"]
         },
         {
           "Id": 2,
-          "References": ["I Cor. 6:17", "John 10:28", "Eph. 5:23, 30"]
+          "References": ["1Cor.6.17", "John.10.28", "Eph.5.23,Eph.5.30"]
         },
         {
           "Id": 3,
-          "References": ["I Peter 5:10", "I Cor. 1:9"]
+          "References": ["1Pet.5.10", "1Cor.1.9"]
         }
       ]
     },
@@ -1630,27 +1630,27 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["John 5:25", "Eph. 1:18-20", "II Tim. 1:8-9"]
+          "References": ["John.5.25", "Eph.1.18-Eph.1.20", "2Tim.1.8-2Tim.1.9"]
         },
         {
           "Id": 2,
-          "References": ["Titus. 3:4-5", "Eph. 2:4-5, 7-9", "Rom. 9:11"]
+          "References": ["Titus.3.4-Titus.3.5", "Eph.2.4-Eph.2.5,Eph.2.7-Eph.2.9", "Rom.9.11"]
         },
         {
           "Id": 3,
-          "References": ["II Cor. 5:20", "II Cor. 6:1-2", "John 6:44", "II Thess. 2:13-14"]
+          "References": ["2Cor.5.20", "2Cor.6.1-2Cor.6.2", "John.6.44", "2Thess.2.13-2Thess.2.14"]
         },
         {
           "Id": 4,
-          "References": ["Acts 26:18", "I Cor. 2:10, 12"]
+          "References": ["Acts.26.18", "1Cor.2.10,1Cor.2.12"]
         },
         {
           "Id": 5,
-          "References": ["Ezek. 11:19", "Ezek. 36:26-27", "John 6:45"]
+          "References": ["Ezek.11.19", "Ezek.36.26-Ezek.36.27", "John.6.45"]
         },
         {
           "Id": 6,
-          "References": ["Eph. 2:5", "Phil. 2:13", "Deut. 30:6"]
+          "References": ["Eph.2.5", "Phil.2.13", "Deut.30.6"]
         }
       ]
     },
@@ -1662,19 +1662,19 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Acts 13:48"]
+          "References": ["Acts.13.48"]
         },
         {
           "Id": 2,
-          "References": ["Matt. 22:14"]
+          "References": ["Matt.22.14"]
         },
         {
           "Id": 3,
-          "References": ["Matt. 7:22", "Matt. 13:20-21", "Heb. 6:4-6"]
+          "References": ["Matt.7.22", "Matt.13.20-Matt.13.21", "Heb.6.4-Heb.6.6"]
         },
         {
           "Id": 4,
-          "References": ["John 6:64-65", "John 12:38-40", "Acts 18:25-27", "Psa. 81:11-12"]
+          "References": ["John.6.64-John.6.65", "John.12.38-John.12.40", "Acts.18.25-Acts.18.27", "Ps.81.11-Ps.81.12"]
         }
       ]
     },
@@ -1686,15 +1686,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Rom. 8:30"]
+          "References": ["Rom.8.30"]
         },
         {
           "Id": 2,
-          "References": ["Eph. 1:5"]
+          "References": ["Eph.1.5"]
         },
         {
           "Id": 3,
-          "References": ["I Cor. 1:30"]
+          "References": ["1Cor.1.30"]
         }
       ]
     },
@@ -1706,23 +1706,23 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Rom. 3:22, 24-25", "Rom. 4:5"]
+          "References": ["Rom.3.22,Rom.3.24-Rom.3.25", "Rom.4.5"]
         },
         {
           "Id": 2,
-          "References": ["II Cor. 5:19, 21", "Rom. 3:22-25, 27-28"]
+          "References": ["2Cor.5.19,2Cor.5.21", "Rom.3.22-Rom.3.25,Rom.3.27-Rom.3.28"]
         },
         {
           "Id": 3,
-          "References": ["Titus 3:5, 7", "Eph. 1:7"]
+          "References": ["Titus.3.5,Titus.3.7", "Eph.1.7"]
         },
         {
           "Id": 4,
-          "References": ["Rom. 4:6-8", "Rom. 5:17-19"]
+          "References": ["Rom.4.6-Rom.4.8", "Rom.5.17-Rom.5.19"]
         },
         {
           "Id": 5,
-          "References": ["Acts 10:43", "Gal. 2:16", "Phil. 3:9"]
+          "References": ["Acts.10.43", "Gal.2.16", "Phil.3.9"]
         }
       ]
     },
@@ -1734,27 +1734,27 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Rom. 5:8-10, 19"]
+          "References": ["Rom.5.8-Rom.5.10,Rom.5.19"]
         },
         {
           "Id": 2,
-          "References": ["II Tim. 2:5-6", "Heb. 7:22", "Heb. 10:10", "Matt. 20:28", "Dan. 9:24, 26", "Isa. 53:4-6, 10-12", "Rom. 8:32", "I Peter 1:18-19"]
+          "References": ["2Tim.2.5-2Tim.2.6", "Heb.7.22", "Heb.10.10", "Matt.20.28", "Dan.9.24,Dan.9.26", "Isa.53.4-Isa.53.6,Isa.53.10-Isa.53.12", "Rom.8.32", "1Pet.1.18-1Pet.1.19"]
         },
         {
           "Id": 3,
-          "References": ["II Cor. 5:21"]
+          "References": ["2Cor.5.21"]
         },
         {
           "Id": 4,
-          "References": ["Rom. 3:24-25"]
+          "References": ["Rom.3.24-Rom.3.25"]
         },
         {
           "Id": 5,
-          "References": ["Eph. 2:8"]
+          "References": ["Eph.2.8"]
         },
         {
           "Id": 6,
-          "References": ["Eph. 1:7"]
+          "References": ["Eph.1.7"]
         }
       ]
     },
@@ -1766,31 +1766,31 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Heb. 10:39"]
+          "References": ["Heb.10.39"]
         },
         {
           "Id": 2,
-          "References": ["II Cor. 4:13", "Eph. 1:17-19"]
+          "References": ["2Cor.4.13", "Eph.1.17-Eph.1.19"]
         },
         {
           "Id": 3,
-          "References": ["Rom. 10:14, 17"]
+          "References": ["Rom.10.14,Rom.10.17"]
         },
         {
           "Id": 4,
-          "References": ["Acts 2:37", "Acts 4:12", "Acts 16:30", "John 16:8-9", "Rom. 5:6", "Eph. 2:1"]
+          "References": ["Acts.2.37", "Acts.4.12", "Acts.16.30", "John.16.8-John.16.9", "Rom.5.6", "Eph.2.1"]
         },
         {
           "Id": 5,
-          "References": ["Eph. 1:13"]
+          "References": ["Eph.1.13"]
         },
         {
           "Id": 6,
-          "References": ["John 1:12", "Acts 10:43", "Acts 16:31"]
+          "References": ["John.1.12", "Acts.10.43", "Acts.16.31"]
         },
         {
           "Id": 7,
-          "References": ["Phil. 3:9", "Acts 15:11"]
+          "References": ["Phil.3.9", "Acts.15.11"]
         }
       ]
     },
@@ -1802,15 +1802,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Gal. 3:11", "Rom. 3:28"]
+          "References": ["Gal.3.11", "Rom.3.28"]
         },
         {
           "Id": 2,
-          "References": ["Rom. 4:5", "Rom. 10:10"]
+          "References": ["Rom.4.5", "Rom.10.10"]
         },
         {
           "Id": 3,
-          "References": ["John 1:12", "Phil. 3:9", "Gal. 2:16"]
+          "References": ["John.1.12", "Phil.3.9", "Gal.2.16"]
         }
       ]
     },
@@ -1822,31 +1822,31 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["I John 3:1"]
+          "References": ["1John.3.1"]
         },
         {
           "Id": 2,
-          "References": ["Eph. 1:5", "Gal. 4:4-5"]
+          "References": ["Eph.1.5", "Gal.4.4-Gal.4.5"]
         },
         {
           "Id": 3,
-          "References": ["John 1:12"]
+          "References": ["John.1.12"]
         },
         {
           "Id": 4,
-          "References": ["II Cor. 4:18", "Rev. 3:12"]
+          "References": ["2Cor.4.18", "Rev.3.12"]
         },
         {
           "Id": 5,
-          "References": ["Gal. 4:6"]
+          "References": ["Gal.4.6"]
         },
         {
           "Id": 6,
-          "References": ["Psa. 103:13", "Prov. 14:26", "Matt. 6:32"]
+          "References": ["Ps.103.13", "Prov.14.26", "Matt.6.32"]
         },
         {
           "Id": 7,
-          "References": ["Heb. 6:12", "Rom. 8:17"]
+          "References": ["Heb.6.12", "Rom.8.17"]
         }
       ]
     },
@@ -1858,27 +1858,27 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Eph. 1:4", "I Cor. 6:11", "II Thess. 2:13"]
+          "References": ["Eph.1.4", "1Cor.6.11", "2Thess.2.13"]
         },
         {
           "Id": 2,
-          "References": ["Rom. 6:4-6"]
+          "References": ["Rom.6.4-Rom.6.6"]
         },
         {
           "Id": 3,
-          "References": ["Eph. 4:23-24"]
+          "References": ["Eph.4.23-Eph.4.24"]
         },
         {
           "Id": 4,
-          "References": ["Acts 11:18", "I John 3:9"]
+          "References": ["Acts.11.18", "1John.3.9"]
         },
         {
           "Id": 5,
-          "References": ["Jude 1:20", "Heb. 6:11-12", "Eph. 3:16-19", "Col. 1:10-11"]
+          "References": ["Jude.1.20", "Heb.6.11-Heb.6.12", "Eph.3.16-Eph.3.19", "Col.1.10-Col.1.11"]
         },
         {
           "Id": 6,
-          "References": ["Rom. 6:4", "Rom. 6:14", "Gal. 5:24"]
+          "References": ["Rom.6.4", "Rom.6.14", "Gal.5.24"]
         }
       ]
     },
@@ -1890,43 +1890,43 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["II Tim. 2:25"]
+          "References": ["2Tim.2.25"]
         },
         {
           "Id": 2,
-          "References": ["Zech. 12:10"]
+          "References": ["Zech.12.10"]
         },
         {
           "Id": 3,
-          "References": ["Acts 11:18, 20-21"]
+          "References": ["Acts.11.18,Acts.11.20-Acts.11.21"]
         },
         {
           "Id": 4,
-          "References": ["Ezek. 18:28, 30, 32", "Luke 15:17-18", "Hosea 2:6-7"]
+          "References": ["Ezek.18.28,Ezek.18.30,Ezek.18.32", "Luke.15.17-Luke.15.18", "Hos.2.6-Hos.2.7"]
         },
         {
           "Id": 5,
-          "References": ["Ezek. 36:31", "Isa. 30:22"]
+          "References": ["Ezek.36.31", "Isa.30.22"]
         },
         {
           "Id": 6,
-          "References": ["Joel 2:12-13"]
+          "References": ["Joel.2.12-Joel.2.13"]
         },
         {
           "Id": 7,
-          "References": ["Jer. 31:18-19"]
+          "References": ["Jer.31.18-Jer.31.19"]
         },
         {
           "Id": 8,
-          "References": ["II Cor. 7:11"]
+          "References": ["2Cor.7.11"]
         },
         {
           "Id": 9,
-          "References": ["Acts 26:18", "Ezek. 14:6", "I Kings 8:47-48"]
+          "References": ["Acts.26.18", "Ezek.14.6", "1Kgs.8.47-1Kgs.8.48"]
         },
         {
           "Id": 10,
-          "References": ["Psa. 119:6, 59, 128", "Luke 1:6", "II Kings 23:25"]
+          "References": ["Ps.119.6,Ps.119.59,Ps.119.128", "Luke.1.6", "2Kgs.23.25"]
         }
       ]
     },
@@ -1938,39 +1938,39 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["I Cor. 1:30", "I Cor. 6:11"]
+          "References": ["1Cor.1.30", "1Cor.6.11"]
         },
         {
           "Id": 2,
-          "References": ["Rom. 4:6, 8"]
+          "References": ["Rom.4.6,Rom.4.8"]
         },
         {
           "Id": 3,
-          "References": ["Ezek. 36:27"]
+          "References": ["Ezek.36.27"]
         },
         {
           "Id": 4,
-          "References": ["Rom. 3:24-25"]
+          "References": ["Rom.3.24-Rom.3.25"]
         },
         {
           "Id": 5,
-          "References": ["Rom. 6:6, 14"]
+          "References": ["Rom.6.6,Rom.6.14"]
         },
         {
           "Id": 6,
-          "References": ["Rom. 8:33-34"]
+          "References": ["Rom.8.33-Rom.8.34"]
         },
         {
           "Id": 7,
-          "References": ["I John 2:12-14", "Heb. 5:12-14"]
+          "References": ["1John.2.12-1John.2.14", "Heb.5.12-Heb.5.14"]
         },
         {
           "Id": 8,
-          "References": ["I John 1:8, 10"]
+          "References": ["1John.1.8,1John.1.10"]
         },
         {
           "Id": 9,
-          "References": ["II Cor. 7:1", "Phil 3:12-14"]
+          "References": ["2Cor.7.1", "Phil.3.12-Phil.3.14"]
         }
       ]
     },
@@ -1982,15 +1982,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Rom. 7:18, 23", "Mark 14:66-72 ", "Gal. 2:11-12"]
+          "References": ["Rom.7.18,Rom.7.23", "Mark.14.66-Mark.14.72", "Gal.2.11-Gal.2.12"]
         },
         {
           "Id": 2,
-          "References": ["Heb. 12:1"]
+          "References": ["Heb.12.1"]
         },
         {
           "Id": 3,
-          "References": ["Isa. 64:6", "Exod. 28:38"]
+          "References": ["Isa.64.6", "Exod.28.38"]
         }
       ]
     },
@@ -2002,31 +2002,31 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Jer. 31:3"]
+          "References": ["Jer.31.3"]
         },
         {
           "Id": 2,
-          "References": ["II Tim. 2:19-21", "II Sam. 23:5"]
+          "References": ["2Tim.2.19-2Tim.2.21", "2Sam.23.5"]
         },
         {
           "Id": 3,
-          "References": ["I Cor. 1:8-9"]
+          "References": ["1Cor.1.8-1Cor.1.9"]
         },
         {
           "Id": 4,
-          "References": ["Heb. 7:25", "Luke 22:32"]
+          "References": ["Heb.7.25", "Luke.22.32"]
         },
         {
           "Id": 5,
-          "References": ["I John 2:27", "I John 3:9"]
+          "References": ["1John.2.27", "1John.3.9"]
         },
         {
           "Id": 6,
-          "References": ["Jer. 32:40", "John 10:28"]
+          "References": ["Jer.32.40", "John.10.28"]
         },
         {
           "Id": 7,
-          "References": ["I Peter 1:5"]
+          "References": ["1Pet.1.5"]
         }
       ]
     },
@@ -2038,19 +2038,19 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["1 John 2:3"]
+          "References": ["1John.2.3"]
         },
         {
           "Id": 2,
-          "References": ["I Cor. 2:12", "I John 3:14, 18-19, 21, 24", "I John 4:13, 16", "Heb. 6:11-12"]
+          "References": ["1Cor.2.12", "1John.3.14,1John.3.18-1John.3.19,1John.3.21,1John.3.24", "1John.4.13,1John.4.16", "Heb.6.11-Heb.6.12"]
         },
         {
           "Id": 3,
-          "References": ["Rom. 8:16"]
+          "References": ["Rom.8.16"]
         },
         {
           "Id": 4,
-          "References": ["I John 5:13"]
+          "References": ["1John.5.13"]
         }
       ]
     },
@@ -2062,19 +2062,19 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Eph. 1:13"]
+          "References": ["Eph.1.13"]
         },
         {
           "Id": 2,
-          "References": ["Isa. 50:10", "Psa. ch. 88"]
+          "References": ["Isa.50.10", "Ps.88"]
         },
         {
           "Id": 3,
-          "References": ["Psa. 22:1", "Psa. 31:22", "Psa. 51:8, 12", "Psa. 77:1-12", "Song of Sol. 5:2-3, 6"]
+          "References": ["Ps.22.1", "Ps.31.22", "Ps.51.8,Ps.51.12", "Ps.77.1-Ps.77.12", "Song.5.2-Song.5.3,Song.5.6"]
         },
         {
           "Id": 4,
-          "References": ["I John 3:9", "Job 13:15", "Psa. 73:15, 23", "Isa. 54:7-10"]
+          "References": ["1John.3.9", "Job.13.15", "Ps.73.15,Ps.73.23", "Isa.54.7-Isa.54.10"]
         }
       ]
     },
@@ -2086,15 +2086,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["II Cor. 3:18"]
+          "References": ["2Cor.3.18"]
         },
         {
           "Id": 2,
-          "References": ["Luke 23:43"]
+          "References": ["Luke.23.43"]
         },
         {
           "Id": 3,
-          "References": ["I Thess. 4:17"]
+          "References": ["1Thess.4.17"]
         }
       ]
     },
@@ -2106,19 +2106,19 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Eph. 2:5"]
+          "References": ["Eph.2.5"]
         },
         {
           "Id": 2,
-          "References": ["Rom. 5:5", "II Cor. 1:22"]
+          "References": ["Rom.5.5", "2Cor.1.22"]
         },
         {
           "Id": 3,
-          "References": ["Rom. 5:1-2", "Rom. 14:17"]
+          "References": ["Rom.5.1-Rom.5.2", "Rom.14.17"]
         },
         {
           "Id": 4,
-          "References": ["Gen. 4:13", "Matt. 27:4", "Heb. 10:27", "Rom. 2:9", "Mark 9:44"]
+          "References": ["Gen.4.13", "Matt.27.4", "Heb.10.27", "Rom.2.9", "Mark.9.44"]
         }
       ]
     },
@@ -2130,15 +2130,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Rom. 6:23"]
+          "References": ["Rom.6.23"]
         },
         {
           "Id": 2,
-          "References": ["Heb. 9:27"]
+          "References": ["Heb.9.27"]
         },
         {
           "Id": 3,
-          "References": ["Rom. 5:12"]
+          "References": ["Rom.5.12"]
         }
       ]
     },
@@ -2150,19 +2150,19 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["I Cor. 15:26, 55-57", "Heb. 2:15"]
+          "References": ["1Cor.15.26,1Cor.15.55-1Cor.15.57", "Heb.2.15"]
         },
         {
           "Id": 2,
-          "References": ["Isa. 57:1-2", "II Kings 22:20"]
+          "References": ["Isa.57.1-Isa.57.2", "2Kgs.22.20"]
         },
         {
           "Id": 3,
-          "References": ["Rev. 14:13", "Eph. 5:27"]
+          "References": ["Rev.14.13", "Eph.5.27"]
         },
         {
           "Id": 4,
-          "References": ["Luke 23:43", "Phil 1:23"]
+          "References": ["Luke.23.43", "Phil.1.23"]
         }
       ]
     },
@@ -2174,35 +2174,35 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Heb. 12:23"]
+          "References": ["Heb.12.23"]
         },
         {
           "Id": 2,
-          "References": ["II Cor. 5:1, 6, 8", "Phil 1:23", "Acts 3:21", "Eph. 4:10"]
+          "References": ["2Cor.5.1,2Cor.5.6,2Cor.5.8", "Phil.1.23", "Acts.3.21", "Eph.4.10"]
         },
         {
           "Id": 3,
-          "References": ["I John 3:2", "I Cor. 13:12"]
+          "References": ["1John.3.2", "1Cor.13.12"]
         },
         {
           "Id": 4,
-          "References": ["Rom. 8:23", "Psa. 16:9"]
+          "References": ["Rom.8.23", "Ps.16.9"]
         },
         {
           "Id": 5,
-          "References": ["I Thess. 4:14"]
+          "References": ["1Thess.4.14"]
         },
         {
           "Id": 6,
-          "References": ["Isa. 57:2"]
+          "References": ["Isa.57.2"]
         },
         {
           "Id": 7,
-          "References": ["Job 19:26-27"]
+          "References": ["Job.19.26-Job.19.27"]
         },
         {
           "Id": 8,
-          "References": ["Luke 16:23-24", "Acts 1:25", "Jude 1:6-7"]
+          "References": ["Luke.16.23-Luke.16.24", "Acts.1.25", "Jude.1.6-Jude.1.7"]
         }
       ]
     },
@@ -2214,19 +2214,19 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Acts 24:15"]
+          "References": ["Acts.24.15"]
         },
         {
           "Id": 2,
-          "References": ["I Cor. 15:51-53", "I Thess. 4:15-17", "John 5:28-29"]
+          "References": ["1Cor.15.51-1Cor.15.53", "1Thess.4.15-1Thess.4.17", "John.5.28-John.5.29"]
         },
         {
           "Id": 3,
-          "References": ["I Cor. 15:21-23, 42-44", "Phil. 3:21"]
+          "References": ["1Cor.15.21-1Cor.15.23,1Cor.15.42-1Cor.15.44", "Phil.3.21"]
         },
         {
           "Id": 4,
-          "References": ["John 5:27-29", "Matt. 25:33"]
+          "References": ["John.5.27-John.5.29", "Matt.25.33"]
         }
       ]
     },
@@ -2238,11 +2238,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["II Peter 2:4", "Jude 1:6-7, 14-15", "Matt. 25:46"]
+          "References": ["2Pet.2.4", "Jude.1.6-Jude.1.7,Jude.1.14-Jude.1.15", "Matt.25.46"]
         },
         {
           "Id": 2,
-          "References": ["Matt. 24:36, 42, 44", "Luke 21:35-36"]
+          "References": ["Matt.24.36,Matt.24.42,Matt.24.44", "Luke.21.35-Luke.21.36"]
         }
       ]
     },
@@ -2254,19 +2254,19 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 25:33"]
+          "References": ["Matt.25.33"]
         },
         {
           "Id": 2,
-          "References": ["Rom. 2:15-16"]
+          "References": ["Rom.2.15-Rom.2.16"]
         },
         {
           "Id": 3,
-          "References": ["Matt. 25:41-43"]
+          "References": ["Matt.25.41-Matt.25.43"]
         },
         {
           "Id": 4,
-          "References": ["Luke 16:26", "II Thess. 1:8-9"]
+          "References": ["Luke.16.26", "2Thess.1.8-2Thess.1.9"]
         }
       ]
     },
@@ -2278,35 +2278,35 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["I Thess. 4:17"]
+          "References": ["1Thess.4.17"]
         },
         {
           "Id": 2,
-          "References": ["Matt. 10:32, 25:33"]
+          "References": ["Matt.10.32,Matt.25.33"]
         },
         {
           "Id": 3,
-          "References": ["I Cor. 6:2-3"]
+          "References": ["1Cor.6.2-1Cor.6.3"]
         },
         {
           "Id": 4,
-          "References": ["Matt. 25:34, 46"]
+          "References": ["Matt.25.34,Matt.25.46"]
         },
         {
           "Id": 5,
-          "References": ["Eph. 5:27", "Rev. 14:13"]
+          "References": ["Eph.5.27", "Rev.14.13"]
         },
         {
           "Id": 6,
-          "References": ["Psa. 16:11"]
+          "References": ["Ps.16.11"]
         },
         {
           "Id": 7,
-          "References": ["Heb. 12:22-23"]
+          "References": ["Heb.12.22-Heb.12.23"]
         },
         {
           "Id": 8,
-          "References": ["I John 3:2", "I Cor. 13:12", "I Thess. 4:17-18"]
+          "References": ["1John.3.2", "1Cor.13.12", "1Thess.4.17-1Thess.4.18"]
         }
       ]
     },
@@ -2318,7 +2318,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Rom. 12:1-2", "Micah 6:8", "I Sam. 15:22"]
+          "References": ["Rom.12.1-Rom.12.2", "Mic.6.8", "1Sam.15.22"]
         }
       ]
     },
@@ -2330,7 +2330,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Gen. 1:26-27", "Gen. 2:17", "Rom. 2:14-15", "Rom. 10:5"]
+          "References": ["Gen.1.26-Gen.1.27", "Gen.2.17", "Rom.2.14-Rom.2.15", "Rom.10.5"]
         }
       ]
     },
@@ -2342,15 +2342,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Deut. 5:1-3, 31, 33", "Luke 10:26-27", "Gal. 3:10", "I Thess. 5:23"]
+          "References": ["Deut.5.1-Deut.5.3,Deut.5.31,Deut.5.33", "Luke.10.26-Luke.10.27", "Gal.3.10", "1Thess.5.23"]
         },
         {
           "Id": 2,
-          "References": ["Luke 1:75", "Acts 14:16"]
+          "References": ["Luke.1.75", "Acts.14.16"]
         },
         {
           "Id": 3,
-          "References": ["Rom. 10:5", "Gal. 3:10, 12"]
+          "References": ["Rom.10.5", "Gal.3.10,Gal.3.12"]
         }
       ]
     },
@@ -2362,11 +2362,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Rom. 8:3", "Gal. 2:16"]
+          "References": ["Rom.8.3", "Gal.2.16"]
         },
         {
           "Id": 2,
-          "References": ["I Tim. 1:8"]
+          "References": ["1Tim.1.8"]
         }
       ]
     },
@@ -2378,27 +2378,27 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Lev. 11:44-45", "Lev. 20:7-8", "Rom. 7:12"]
+          "References": ["Lev.11.44-Lev.11.45", "Lev.20.7-Lev.20.8", "Rom.7.12"]
         },
         {
           "Id": 2,
-          "References": ["Micah 6:8", "James 2:10-11"]
+          "References": ["Mic.6.8", "Jas.2.10-Jas.2.11"]
         },
         {
           "Id": 3,
-          "References": ["Psa. 19:11-12", "Rom. 3:20", "Rom. 7:7"]
+          "References": ["Ps.19.11-Ps.19.12", "Rom.3.20", "Rom.7.7"]
         },
         {
           "Id": 4,
-          "References": ["Rom. 3:9, 23"]
+          "References": ["Rom.3.9,Rom.3.23"]
         },
         {
           "Id": 5,
-          "References": ["Gal. 3:21-22"]
+          "References": ["Gal.3.21-Gal.3.22"]
         },
         {
           "Id": 6,
-          "References": ["Rom. 10:4"]
+          "References": ["Rom.10.4"]
         }
       ]
     },
@@ -2410,19 +2410,19 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["I Tim. 1:9-10"]
+          "References": ["1Tim.1.9-1Tim.1.10"]
         },
         {
           "Id": 2,
-          "References": ["Gal. 3:24"]
+          "References": ["Gal.3.24"]
         },
         {
           "Id": 3,
-          "References": ["Rom. 1:20", "Rom. 2:15"]
+          "References": ["Rom.1.20", "Rom.2.15"]
         },
         {
           "Id": 4,
-          "References": ["Gal. 3:10"]
+          "References": ["Gal.3.10"]
         }
       ]
     },
@@ -2434,27 +2434,27 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Rom. 6:14", "Rom. 7:4, 6", "Gal. 4:4-5"]
+          "References": ["Rom.6.14", "Rom.7.4,Rom.7.6", "Gal.4.4-Gal.4.5"]
         },
         {
           "Id": 2,
-          "References": ["Rom. 3:20"]
+          "References": ["Rom.3.20"]
         },
         {
           "Id": 3,
-          "References": ["Gal. 5:23", "Rom. 8:1"]
+          "References": ["Gal.5.23", "Rom.8.1"]
         },
         {
           "Id": 4,
-          "References": ["Rom. 7:24-25", "Rom. 8:3-4", "Gal. 3:13-14"]
+          "References": ["Rom.7.24-Rom.7.25", "Rom.8.3-Rom.8.4", "Gal.3.13-Gal.3.14"]
         },
         {
           "Id": 5,
-          "References": ["Luke 1:68-69, 74-75", "Col. 1:12-14"]
+          "References": ["Luke.1.68-Luke.1.69,Luke.1.74-Luke.1.75", "Col.1.12-Col.1.14"]
         },
         {
           "Id": 6,
-          "References": ["Rom. 7:22", "Rom. 12:2", "Titus 2:11-14"]
+          "References": ["Rom.7.22", "Rom.12.2", "Titus.2.11-Titus.2.14"]
         }
       ]
     },
@@ -2466,11 +2466,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Deut. 10:4", "Exod. 34:1-4"]
+          "References": ["Deut.10.4", "Exod.34.1-Exod.34.4"]
         },
         {
           "Id": 2,
-          "References": ["Matt. 22:37-38, 40"]
+          "References": ["Matt.22.37-Matt.22.38,Matt.22.40"]
         }
       ]
     },
@@ -2482,59 +2482,59 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Psa. 19:7", "James 2:10", "Matt. 5:21-22"]
+          "References": ["Ps.19.7", "Jas.2.10", "Matt.5.21-Matt.5.22"]
         },
         {
           "Id": 2,
-          "References": ["Rom. 7:14", "Deut. 6:5", "Matt. 5:21-22, 27-28, 33-34, 37-39, 43-44", "Matt. 22:37-39"]
+          "References": ["Rom.7.14", "Deut.6.5", "Matt.5.21-Matt.5.22,Matt.5.27-Matt.5.28,Matt.5.33-Matt.5.34,Matt.5.37-Matt.5.39,Matt.5.43-Matt.5.44", "Matt.22.37-Matt.22.39"]
         },
         {
           "Id": 3,
-          "References": ["Col. 3:5", "Amos 8:5", "Prov. 1:19", "I Tim. 6:10"]
+          "References": ["Col.3.5", "Amos.8.5", "Prov.1.19", "1Tim.6.1"]
         },
         {
           "Id": 4,
-          "References": ["Isa. 58:13", "Deut. 6:13", "Matt. 4:9-10", "Matt. 15:4-6"]
+          "References": ["Isa.58.13", "Deut.6.13", "Matt.4.9-Matt.4.10", "Matt.15.4-Matt.15.6"]
         },
         {
           "Id": 5,
-          "References": ["Matt. 5:21-25", "Eph. 4:28"]
+          "References": ["Matt.5.21-Matt.5.25", "Eph.4.28"]
         },
         {
           "Id": 6,
-          "References": ["Exod. 20:12", "Prov. 30:17"]
+          "References": ["Exod.20.12", "Prov.30.17"]
         },
         {
           "Id": 7,
-          "References": ["Jer. 18:7-8", "Exod. 20:7", "Psa. 15:1, 4-5", "Psa. 24:4-5"]
+          "References": ["Jer.18.7-Jer.18.8", "Exod.20.7", "Ps.15.1,Ps.15.4-Ps.15.5", "Ps.24.4-Ps.24.5"]
         },
         {
           "Id": 8,
-          "References": ["Job. 13:7", "Job. 36:21", "Rom. 3:8", "Heb. 11:25"]
+          "References": ["Job.13.7", "Job.36.21", "Rom.3.8", "Heb.11.25"]
         },
         {
           "Id": 9,
-          "References": ["Deut. 4:8-9"]
+          "References": ["Deut.4.8-Deut.4.9"]
         },
         {
           "Id": 10,
-          "References": ["Matt. 12:7"]
+          "References": ["Matt.12.7"]
         },
         {
           "Id": 11,
-          "References": ["Matt. 5:21-22, 27-28", "Matt. 15:4-6", "Heb. 10:24-25", "I Thess. 5:22-23", "Gal. 5:26", "Col. 3:21"]
+          "References": ["Matt.5.21-Matt.5.22,Matt.5.27-Matt.5.28", "Matt.15.4-Matt.15.6", "Heb.10.24-Heb.10.25", "1Thess.5.22-1Thess.5.23", "Gal.5.26", "Col.3.21"]
         },
         {
           "Id": 12,
-          "References": ["Exod. 20:10", "Lev. 19:17", "Gen. 18:19", "Josh. 24:15", "Deut. 6:6-7"]
+          "References": ["Exod.20.10", "Lev.19.17", "Gen.18.19", "Josh.24.15", "Deut.6.6-Deut.6.7"]
         },
         {
           "Id": 13,
-          "References": ["II Cor. 1:24"]
+          "References": ["2Cor.1.24"]
         },
         {
           "Id": 14,
-          "References": ["I Tim. 5:22"]
+          "References": ["1Tim.5.22"]
         }
       ]
     },
@@ -2553,35 +2553,35 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Exod. 20:2"]
+          "References": ["Exod.20.2"]
         },
         {
           "Id": 2,
-          "References": ["Isa. 44:6"]
+          "References": ["Isa.44.6"]
         },
         {
           "Id": 3,
-          "References": ["Exod. 3:14"]
+          "References": ["Exod.3.14"]
         },
         {
           "Id": 4,
-          "References": ["Exod. 6:3"]
+          "References": ["Exod.6.3"]
         },
         {
           "Id": 5,
-          "References": ["Acts 17:24, 28"]
+          "References": ["Acts.17.24,Acts.17.28"]
         },
         {
           "Id": 6,
-          "References": ["Gen. 17:7", "Rom. 3:29"]
+          "References": ["Gen.17.7", "Rom.3.29"]
         },
         {
           "Id": 7,
-          "References": ["Luke 1:74-75"]
+          "References": ["Luke.1.74-Luke.1.75"]
         },
         {
           "Id": 8,
-          "References": ["I Peter 1:15-18", "Lev. 18:30, 19:37"]
+          "References": ["1Pet.1.15-1Pet.1.18", "Lev.18.30,Lev.19.37"]
         }
       ]
     },
@@ -2593,7 +2593,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Luke 10:27"]
+          "References": ["Luke.10.27"]
         }
       ]
     },
@@ -2605,7 +2605,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Exod. 20:3"]
+          "References": ["Exod.20.3"]
         }
       ]
     },
@@ -2617,95 +2617,95 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["I Chr. 28:9", "Deut 26:17", "Isa. 43:10", "Jer. 14:22"]
+          "References": ["1Chr.28.9", "Deut.26.17", "Isa.43.10", "Jer.14.22"]
         },
         {
           "Id": 2,
-          "References": ["Psa. 29:2", "Psa. 95:6-7", "Matt. 4:10"]
+          "References": ["Ps.29.2", "Ps.95.6-Ps.95.7", "Matt.4.10"]
         },
         {
           "Id": 3,
-          "References": ["Mal. 3:16"]
+          "References": ["Mal.3.16"]
         },
         {
           "Id": 4,
-          "References": ["Psa. 63:6"]
+          "References": ["Ps.63.6"]
         },
         {
           "Id": 5,
-          "References": ["Eccl. 12:1"]
+          "References": ["Eccl.12.1"]
         },
         {
           "Id": 6,
-          "References": ["Psa. 71:19"]
+          "References": ["Ps.71.19"]
         },
         {
           "Id": 7,
-          "References": ["Mal. 1:6"]
+          "References": ["Mal.1.6"]
         },
         {
           "Id": 8,
-          "References": ["Isa. 45:23"]
+          "References": ["Isa.45.23"]
         },
         {
           "Id": 9,
-          "References": ["Josh. 24:15, 22"]
+          "References": ["Josh.24.15,Josh.24.22"]
         },
         {
           "Id": 10,
-          "References": ["Deut. 6:5"]
+          "References": ["Deut.6.5"]
         },
         {
           "Id": 11,
-          "References": ["Psa. 73:25"]
+          "References": ["Ps.73.25"]
         },
         {
           "Id": 12,
-          "References": ["Isa. 8:13"]
+          "References": ["Isa.8.13"]
         },
         {
           "Id": 13,
-          "References": ["Exod. 14:31"]
+          "References": ["Exod.14.31"]
         },
         {
           "Id": 14,
-          "References": ["Isa. 26:4"]
+          "References": ["Isa.26.4"]
         },
         {
           "Id": 15,
-          "References": ["Psa. 130:7"]
+          "References": ["Ps.130.7"]
         },
         {
           "Id": 16,
-          "References": ["Psa. 37:4"]
+          "References": ["Ps.37.4"]
         },
         {
           "Id": 17,
-          "References": ["Psa. 32:11"]
+          "References": ["Ps.32.11"]
         },
         {
           "Id": 18,
-          "References": ["Rom. 12:11", "Num. 25:11"]
+          "References": ["Rom.12.11", "Num.25.11"]
         },
         {
           "Id": 19,
-          "References": ["Phil. 4:6"]
+          "References": ["Phil.4.6"]
         },
         {
           "Id": 20,
-          "References": ["Jer. 7:28", "James 4:7"]
+          "References": ["Jer.7.28", "Jas.4.7"]
         },
         {
           "Id": 21,
-          "References": ["I John 3:22"]
+          "References": ["1John.3.2"]
         },
         {
           "Id": 22,
-          "References": ["Jer. 31:18", "Psa. 119:136"]
+          "References": ["Jer.31.18", "Ps.119.136"]
         },
         {
           "Id": 23,
-          "References": ["Micah 6:8"]
+          "References": ["Mic.6.8"]
         }
       ]
     },
@@ -2717,187 +2717,187 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Psa. 14:1", "Eph. 2:12"]
+          "References": ["Ps.14.1", "Eph.2.12"]
         },
         {
           "Id": 2,
-          "References": ["Jer. 2:27-28", "I Thess. 1:9"]
+          "References": ["Jer.2.27-Jer.2.28", "1Thess.1.9"]
         },
         {
           "Id": 3,
-          "References": ["Psa. 81:11"]
+          "References": ["Ps.81.11"]
         },
         {
           "Id": 4,
-          "References": ["Isa. 43:22-24"]
+          "References": ["Isa.43.22-Isa.43.24"]
         },
         {
           "Id": 5,
-          "References": ["Jer. 4:22", "Hosea 4:1, 6"]
+          "References": ["Jer.4.22", "Hos.4.1,Hos.4.6"]
         },
         {
           "Id": 6,
-          "References": ["Jer. 2:32"]
+          "References": ["Jer.2.32"]
         },
         {
           "Id": 7,
-          "References": ["Acts 17:23, 29"]
+          "References": ["Acts.17.23,Acts.17.29"]
         },
         {
           "Id": 8,
-          "References": ["Isa. 40:18"]
+          "References": ["Isa.40.18"]
         },
         {
           "Id": 9,
-          "References": ["Psa. 50:21"]
+          "References": ["Ps.50.21"]
         },
         {
           "Id": 10,
-          "References": ["Deut. 29:29"]
+          "References": ["Deut.29.29"]
         },
         {
           "Id": 11,
-          "References": ["Titus 1:16", "Heb. 12:16"]
+          "References": ["Titus.1.16", "Heb.12.16"]
         },
         {
           "Id": 12,
-          "References": ["Rom. 1:30"]
+          "References": ["Rom.1.30"]
         },
         {
           "Id": 13,
-          "References": ["II Tim. 3:2"]
+          "References": ["2Tim.3.2"]
         },
         {
           "Id": 14,
-          "References": ["Phil. 2:21"]
+          "References": ["Phil.2.21"]
         },
         {
           "Id": 15,
-          "References": ["I John 2:15-16", "I Sam. 2:29", "Col. 3:2, 5"]
+          "References": ["1John.2.15-1John.2.16", "1Sam.2.29", "Col.3.2,Col.3.5"]
         },
         {
           "Id": 16,
-          "References": ["I John 4:1"]
+          "References": ["1John.4.1"]
         },
         {
           "Id": 17,
-          "References": ["Heb. 3:12"]
+          "References": ["Heb.3.12"]
         },
         {
           "Id": 18,
-          "References": ["Gal. 5:20", "Titus 3:10"]
+          "References": ["Gal.5.20", "Titus.3.10"]
         },
         {
           "Id": 19,
-          "References": ["Acts 26:9"]
+          "References": ["Acts.26.9"]
         },
         {
           "Id": 20,
-          "References": ["Psa. 78:22"]
+          "References": ["Ps.78.22"]
         },
         {
           "Id": 21,
-          "References": ["Gen. 4:13"]
+          "References": ["Gen.4.13"]
         },
         {
           "Id": 22,
-          "References": ["Jer. 5:3"]
+          "References": ["Jer.5.3"]
         },
         {
           "Id": 23,
-          "References": ["Isa. 42:25"]
+          "References": ["Isa.42.25"]
         },
         {
           "Id": 24,
-          "References": ["Rom. 2:5"]
+          "References": ["Rom.2.5"]
         },
         {
           "Id": 25,
-          "References": ["Jer. 13:15"]
+          "References": ["Jer.13.15"]
         },
         {
           "Id": 26,
-          "References": ["Psa. 19:13"]
+          "References": ["Ps.19.13"]
         },
         {
           "Id": 27,
-          "References": ["Zeph. 1:12"]
+          "References": ["Zeph.1.12"]
         },
         {
           "Id": 28,
-          "References": ["Matt. 4:7"]
+          "References": ["Matt.4.7"]
         },
         {
           "Id": 29,
-          "References": ["Rom. 3:8"]
+          "References": ["Rom.3.8"]
         },
         {
           "Id": 30,
-          "References": ["Jer. 17:5"]
+          "References": ["Jer.17.5"]
         },
         {
           "Id": 31,
-          "References": ["II Tim. 3:4"]
+          "References": ["2Tim.3.4"]
         },
         {
           "Id": 32,
-          "References": ["Gal. 4:17", "John 16:2", "Rom. 10:2", "Luke 9:54-55"]
+          "References": ["Gal.4.17", "John.16.2", "Rom.10.2", "Luke.9.54-Luke.9.55"]
         },
         {
           "Id": 33,
-          "References": ["Rev. 3:16"]
+          "References": ["Rev.3.16"]
         },
         {
           "Id": 34,
-          "References": ["Rev. 3:1"]
+          "References": ["Rev.3.1"]
         },
         {
           "Id": 35,
-          "References": ["Ezek. 14:5", "Isa. 1:4-5"]
+          "References": ["Ezek.14.5", "Isa.1.4-Isa.1.5"]
         },
         {
           "Id": 36,
-          "References": ["Rom. 1:25, 10:13-14", "Hosea 4:12", "Acts 10:25-26", "Rev. 19:10", "Matt. 4:10", "Col. 2:18"]
+          "References": ["Rom.1.25,Rom.10.13-Rom.10.14", "Hos.4.12", "Acts.10.25-Acts.10.26", "Rev.19.10", "Matt.4.10", "Col.2.18"]
         },
         {
           "Id": 37,
-          "References": ["Lev. 20:6", "I Sam. 28:7, 11", "I Chr. 10:13-14"]
+          "References": ["Lev.20.6", "1Sam.28.7,1Sam.28.11", "1Chr.10.13-1Chr.10.14"]
         },
         {
           "Id": 38,
-          "References": ["Acts 5:3"]
+          "References": ["Acts.5.3"]
         },
         {
           "Id": 39,
-          "References": ["II Cor. 1:24", "Matt. 23:9"]
+          "References": ["2Cor.1.24", "Matt.23.9"]
         },
         {
           "Id": 40,
-          "References": ["Deut. 32:15", "II Sam. 12:9", "Prov. 13:13"]
+          "References": ["Deut.32.15", "2Sam.12.9", "Prov.13.13"]
         },
         {
           "Id": 41,
-          "References": ["Acts 7:51", "Eph. 4:30"]
+          "References": ["Acts.7.51", "Eph.4.30"]
         },
         {
           "Id": 42,
-          "References": ["Psa. 73:2-3, 13-15, 22", "Job 1:22"]
+          "References": ["Ps.73.2-Ps.73.3,Ps.73.13-Ps.73.15,Ps.73.22", "Job.1.22"]
         },
         {
           "Id": 43,
-          "References": ["I Sam. 6:7-9"]
+          "References": ["1Sam.6.7-1Sam.6.9"]
         },
         {
           "Id": 44,
-          "References": ["Dan. 5:23"]
+          "References": ["Dan.5.23"]
         },
         {
           "Id": 45,
-          "References": ["Deut. 8:17", "Dan. 4:30"]
+          "References": ["Deut.8.17", "Dan.4.30"]
         },
         {
           "Id": 46,
-          "References": ["Hab. 1:16"]
+          "References": ["Hab.1.16"]
         }
       ]
     },
@@ -2909,11 +2909,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ezek. 8:5-18", "Psa. 44:20-21"]
+          "References": ["Ezek.8.5-Ezek.8.18", "Ps.44.20-Ps.44.21"]
         },
         {
           "Id": 2,
-          "References": ["I Chr. 28:9"]
+          "References": ["1Chr.28.9"]
         }
       ]
     },
@@ -2925,7 +2925,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Exod. 20:4-6"]
+          "References": ["Exod.20.4-Exod.20.6"]
         }
       ]
     },
@@ -2937,47 +2937,47 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Deut. 32:46-47", "Matt. 28:20", "Acts 2:42", "I Tim. 6:13-14"]
+          "References": ["Deut.32.46-Deut.32.47", "Matt.28.20", "Acts.2.42", "1Tim.6.13-1Tim.6.14"]
         },
         {
           "Id": 2,
-          "References": ["Phil. 4:6", "Eph. 5:20"]
+          "References": ["Phil.4.6", "Eph.5.20"]
         },
         {
           "Id": 3,
-          "References": ["Deut. 17:18-19", "Acts 15:21", "II Tim. 4:2", "James 1:21-22"]
+          "References": ["Deut.17.18-Deut.17.19", "Acts.15.21", "2Tim.4.2", "Jas.1.21-Jas.1.22"]
         },
         {
           "Id": 4,
-          "References": ["Matt. 28:19", "I Cor. 11:23-30"]
+          "References": ["Matt.28.19", "1Cor.11.23-1Cor.11.30"]
         },
         {
           "Id": 5,
-          "References": ["Matt. 16:19", "Matt. 18:15-17", "I Cor. ch. 5", "I Cor. 12:28"]
+          "References": ["Matt.16.19", "Matt.18.15-Matt.18.17", "1Cor.5", "1Cor.12.28"]
         },
         {
           "Id": 6,
-          "References": ["Eph. 4:11-12", "I Tim. 5:17-18", "I Cor. 9:1-15"]
+          "References": ["Eph.4.11-Eph.4.12", "1Tim.5.17-1Tim.5.18", "1Cor.9.1-1Cor.9.15"]
         },
         {
           "Id": 7,
-          "References": ["Joel 2:12-13", "I Cor. 7:5"]
+          "References": ["Joel.2.12-Joel.2.13", "1Cor.7.5"]
         },
         {
           "Id": 8,
-          "References": ["Deut. 6:13"]
+          "References": ["Deut.6.13"]
         },
         {
           "Id": 9,
-          "References": ["Isa. 19:21", "Psa. 76:11"]
+          "References": ["Isa.19.21", "Ps.76.11"]
         },
         {
           "Id": 10,
-          "References": ["Acts 17:16-17", "Psa. 16:4"]
+          "References": ["Acts.17.16-Acts.17.17", "Ps.16.4"]
         },
         {
           "Id": 11,
-          "References": ["Deut. 7:5", "Isa. 30:22"]
+          "References": ["Deut.7.5", "Isa.30.22"]
         }
       ]
     },
@@ -2989,107 +2989,107 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Num. 15:39"]
+          "References": ["Num.15.39"]
         },
         {
           "Id": 2,
-          "References": ["Deut. 13:6-8"]
+          "References": ["Deut.13.6-Deut.13.8"]
         },
         {
           "Id": 3,
-          "References": ["Hosea 5:11", "Micah 6:16"]
+          "References": ["Hos.5.11", "Mic.6.16"]
         },
         {
           "Id": 4,
-          "References": ["I Kings 11:33", "I Kings 12:33"]
+          "References": ["1Kgs.11.33", "1Kgs.12.33"]
         },
         {
           "Id": 5,
-          "References": ["Deut. 12:30-32"]
+          "References": ["Deut.12.30-Deut.12.32"]
         },
         {
           "Id": 6,
-          "References": ["Deut. 13:6-12", "Zech. 13:2-3", "Rev. 2:2, 14-15, 20, Rev. 17:12, 16-17"]
+          "References": ["Deut.13.6-Deut.13.12", "Zech.13.2-Zech.13.3", "Rev.2.2,Rev.2.14-Rev.2.15,Rev.2.20,Rev.17.12,Rev.17.16-Rev.17.17"]
         },
         {
           "Id": 7,
-          "References": ["Deut. 4:15-19", "Acts 17:29", "Rom. 1:21-23, 25"]
+          "References": ["Deut.4.15-Deut.4.19", "Acts.17.29", "Rom.1.21-Rom.1.23,Rom.1.25"]
         },
         {
           "Id": 8,
-          "References": ["Dan. 3:18", "Gal. 4:8"]
+          "References": ["Dan.3.18", "Gal.4.8"]
         },
         {
           "Id": 9,
-          "References": ["Exod. 32:5"]
+          "References": ["Exod.32.5"]
         },
         {
           "Id": 10,
-          "References": ["Exod. 32:8"]
+          "References": ["Exod.32.8"]
         },
         {
           "Id": 11,
-          "References": ["I Kings 18:26, 28", "Isa. 65:11"]
+          "References": ["1Kgs.18.26,1Kgs.18.28", "Isa.65.11"]
         },
         {
           "Id": 12,
-          "References": ["Acts 17:22", "Col. 2:21-23"]
+          "References": ["Acts.17.22", "Col.2.21-Col.2.23"]
         },
         {
           "Id": 13,
-          "References": ["Mal. 1:7-8, 14"]
+          "References": ["Mal.1.7-Mal.1.8,Mal.1.14"]
         },
         {
           "Id": 14,
-          "References": ["Deut. 4:2"]
+          "References": ["Deut.4.2"]
         },
         {
           "Id": 15,
-          "References": ["Psa. 106:39"]
+          "References": ["Ps.106.39"]
         },
         {
           "Id": 16,
-          "References": ["Matt. 15:9"]
+          "References": ["Matt.15.9"]
         },
         {
           "Id": 17,
-          "References": ["I Peter 1:18"]
+          "References": ["1Pet.1.18"]
         },
         {
           "Id": 18,
-          "References": ["Jer. 44:17"]
+          "References": ["Jer.44.17"]
         },
         {
           "Id": 19,
-          "References": ["Isa. 65:3-5", "Gal. 1:13-14"]
+          "References": ["Isa.65.3-Isa.65.5", "Gal.1.13-Gal.1.14"]
         },
         {
           "Id": 20,
-          "References": ["I Sam. 13:11-12", "I Sam. 15:21"]
+          "References": ["1Sam.13.11-1Sam.13.12", "1Sam.15.21"]
         },
         {
           "Id": 21,
-          "References": ["Acts 8:18"]
+          "References": ["Acts.8.18"]
         },
         {
           "Id": 22,
-          "References": ["Rom. 2:22", "Mal. 3:8"]
+          "References": ["Rom.2.22", "Mal.3.8"]
         },
         {
           "Id": 23,
-          "References": ["Exod. 4:24-26"]
+          "References": ["Exod.4.24-Exod.4.26"]
         },
         {
           "Id": 24,
-          "References": ["Matt. 22:5", "Mal. 1:7, 13"]
+          "References": ["Matt.22.5", "Mal.1.7,Mal.1.13"]
         },
         {
           "Id": 25,
-          "References": ["Matt. 23:13"]
+          "References": ["Matt.23.13"]
         },
         {
           "Id": 26,
-          "References": ["Acts 13:44-45", "I Thess. 2:15-16"]
+          "References": ["Acts.13.44-Acts.13.45", "1Thess.2.15-1Thess.2.16"]
         }
       ]
     },
@@ -3101,27 +3101,27 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Exod. 20:5-6"]
+          "References": ["Exod.20.5-Exod.20.6"]
         },
         {
           "Id": 2,
-          "References": ["Psa. 45:11", "Rev. 20:3-4"]
+          "References": ["Ps.45.11", "Rev.20.3-Rev.20.4"]
         },
         {
           "Id": 3,
-          "References": ["Exod. 34:13-14"]
+          "References": ["Exod.34.13-Exod.34.14"]
         },
         {
           "Id": 4,
-          "References": ["I Cor. 10:20-22", "Jer. 7:18-20", "Ezek. 16:26-27", "Deut. 32:16-20"]
+          "References": ["1Cor.10.20-1Cor.10.22", "Jer.7.18-Jer.7.20", "Ezek.16.26-Ezek.16.27", "Deut.32.16-Deut.32.20"]
         },
         {
           "Id": 5,
-          "References": ["Hosea 2:2-4"]
+          "References": ["Hos.2.2-Hos.2.4"]
         },
         {
           "Id": 6,
-          "References": ["Deut. 5:29"]
+          "References": ["Deut.5.29"]
         }
       ]
     },
@@ -3133,7 +3133,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Exod. 20:7"]
+          "References": ["Exod.20.7"]
         }
       ]
     },
@@ -3145,75 +3145,75 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 6:9", "Deut. 28:58", "Psa. 29:2", "Psa. 68:4", "Rev. 15:3-4"]
+          "References": ["Matt.6.9", "Deut.28.58", "Ps.29.2", "Ps.68.4", "Rev.15.3-Rev.15.4"]
         },
         {
           "Id": 2,
-          "References": ["Mal. 1:14", "Eccl. 5:1"]
+          "References": ["Mal.1.14", "Eccl.5.1"]
         },
         {
           "Id": 3,
-          "References": ["Psa. 138:2"]
+          "References": ["Ps.138.2"]
         },
         {
           "Id": 4,
-          "References": ["I Cor. 11:24-25, 28-29"]
+          "References": ["1Cor.11.24-1Cor.11.25,1Cor.11.28-1Cor.11.29"]
         },
         {
           "Id": 5,
-          "References": ["I Tim. 2:8"]
+          "References": ["1Tim.2.8"]
         },
         {
           "Id": 6,
-          "References": ["Jer. 4:2"]
+          "References": ["Jer.4.2"]
         },
         {
           "Id": 7,
-          "References": ["Eccl. 5:2, 4-6"]
+          "References": ["Eccl.5.2,Eccl.5.4-Eccl.5.6"]
         },
         {
           "Id": 8,
-          "References": ["Acts 1:24, 26"]
+          "References": ["Acts.1.24,Acts.1.26"]
         },
         {
           "Id": 9,
-          "References": ["Job 36:24"]
+          "References": ["Job.36.24"]
         },
         {
           "Id": 10,
-          "References": ["Mal. 3:16"]
+          "References": ["Mal.3.16"]
         },
         {
           "Id": 11,
-          "References": ["Psa. 8:1, 3-4, 9"]
+          "References": ["Ps.8.1,Ps.8.3-Ps.8.4,Ps.8.9"]
         },
         {
           "Id": 12,
-          "References": ["Col. 3:17", "Psa. 105:2, 5"]
+          "References": ["Col.3.17", "Ps.105.2,Ps.105.5"]
         },
         {
           "Id": 13,
-          "References": ["Psa. 102:18"]
+          "References": ["Ps.102.18"]
         },
         {
           "Id": 14,
-          "References": ["I Peter 3:15", "Micah 4:5"]
+          "References": ["1Pet.3.15", "Mic.4.5"]
         },
         {
           "Id": 15,
-          "References": ["Phil. 1:27"]
+          "References": ["Phil.1.27"]
         },
         {
           "Id": 16,
-          "References": ["I Cor. 10:31"]
+          "References": ["1Cor.10.31"]
         },
         {
           "Id": 17,
-          "References": ["Jer. 32:39"]
+          "References": ["Jer.32.39"]
         },
         {
           "Id": 18,
-          "References": ["I Peter 2:12"]
+          "References": ["1Pet.2.12"]
         }
       ]
     },
@@ -3225,159 +3225,159 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Mal. 2:2"]
+          "References": ["Mal.2.2"]
         },
         {
           "Id": 2,
-          "References": ["Acts 17:23"]
+          "References": ["Acts.17.23"]
         },
         {
           "Id": 3,
-          "References": ["Prov. 30:9"]
+          "References": ["Prov.30.9"]
         },
         {
           "Id": 4,
-          "References": ["Mal. 1:6-7, 12", "Mal. 3:14"]
+          "References": ["Mal.1.6-Mal.1.7,Mal.1.12", "Mal.3.14"]
         },
         {
           "Id": 5,
-          "References": ["I Sam. 4:3-5", "Jer. 7:4, 9-10, 14, 31", "Col. 2:20-22"]
+          "References": ["1Sam.4.3-1Sam.4.5", "Jer.7.4,Jer.7.9-Jer.7.10,Jer.7.14,Jer.7.31", "Col.2.20-Col.2.22"]
         },
         {
           "Id": 6,
-          "References": ["II Kings 18:30, 35", "Exod. 5:2", "Psa. 139:20"]
+          "References": ["2Kgs.18.30,2Kgs.18.35", "Exod.5.2", "Ps.139.20"]
         },
         {
           "Id": 7,
-          "References": ["Psa. 50:16-17"]
+          "References": ["Ps.50.16-Ps.50.17"]
         },
         {
           "Id": 8,
-          "References": ["Psa. 50:16-17"]
+          "References": ["Ps.50.16-Ps.50.17"]
         },
         {
           "Id": 9,
-          "References": ["Isa. 5:12"]
+          "References": ["Isa.5.12"]
         },
         {
           "Id": 10,
-          "References": ["II Kings 19:22", "Lev. 24:11"]
+          "References": ["2Kgs.19.22", "Lev.24.11"]
         },
         {
           "Id": 11,
-          "References": ["Zech. 5:4", "Zech. 8:17"]
+          "References": ["Zech.5.4", "Zech.8.17"]
         },
         {
           "Id": 12,
-          "References": ["I Sam. 17:43", "II Sam. 16:5"]
+          "References": ["1Sam.17.43", "2Sam.16.5"]
         },
         {
           "Id": 13,
-          "References": ["Jer. 5:7", "Jer. 23:10"]
+          "References": ["Jer.5.7", "Jer.23.10"]
         },
         {
           "Id": 14,
-          "References": ["Deut. 23:18", "Acts 23:12, 14"]
+          "References": ["Deut.23.18", "Acts.23.12,Acts.23.14"]
         },
         {
           "Id": 15,
-          "References": ["Esth. 3:7", "Esth. 9:24", "Psa. 22:18"]
+          "References": ["Esth.3.7", "Esth.9.24", "Ps.22.18"]
         },
         {
           "Id": 16,
-          "References": ["Psa. 24:4, Ezek. 17:16, 18-19"]
+          "References": ["Ps.24.4,Ezek.17.16,Ezek.17.18-Ezek.17.19"]
         },
         {
           "Id": 17,
-          "References": ["Mark 6:26", "I Sam. 25:22, 32-34"]
+          "References": ["Mark.6.26", "1Sam.25.22,1Sam.25.32-1Sam.25.34"]
         },
         {
           "Id": 18,
-          "References": ["Rom. 9:14, 19-20"]
+          "References": ["Rom.9.14,Rom.9.19-Rom.9.20"]
         },
         {
           "Id": 19,
-          "References": ["Deut. 29:29"]
+          "References": ["Deut.29.29"]
         },
         {
           "Id": 20,
-          "References": ["Rom. 3:5, 7", "Rom. 6:1-2"]
+          "References": ["Rom.3.5,Rom.3.7", "Rom.6.1-Rom.6.2"]
         },
         {
           "Id": 21,
-          "References": ["Eccl. 8:11", "Eccl. 9:3", "Psa. ch. 39"]
+          "References": ["Eccl.8.11", "Eccl.9.3", "Ps.39"]
         },
         {
           "Id": 22,
-          "References": ["Matt. 5:21-48"]
+          "References": ["Matt.5.21-Matt.5.48"]
         },
         {
           "Id": 23,
-          "References": ["Ezek 13:22"]
+          "References": ["Ezek.13.22"]
         },
         {
           "Id": 24,
-          "References": ["II Peter 3:16", "Matt. 22:24-31"]
+          "References": ["2Pet.3.16", "Matt.22.24-Matt.22.31"]
         },
         {
           "Id": 25,
-          "References": ["Isa. 22:18", "Jer. 23:34, 36, 38"]
+          "References": ["Isa.22.18", "Jer.23.34,Jer.23.36,Jer.23.38"]
         },
         {
           "Id": 26,
-          "References": ["I Tim. 1:4, 6-7", "I Tim. 6:4-5, 20", "II Tim. 2:14", "Titus. 3:9"]
+          "References": ["1Tim.1.4,1Tim.1.6-1Tim.1.7", "1Tim.6.4-1Tim.6.5,1Tim.6.20", "2Tim.2.14", "Titus.3.9"]
         },
         {
           "Id": 27,
-          "References": ["Deut. 18:10-14", "Acts 19:13"]
+          "References": ["Deut.18.10-Deut.18.14", "Acts.19.13"]
         },
         {
           "Id": 28,
-          "References": ["II Tim. 4:3-4", "Rom. 13:13-14", "I Kings 21:9-10", "Jude 1:4"]
+          "References": ["2Tim.4.3-2Tim.4.4", "Rom.13.13-Rom.13.14", "1Kgs.21.9-1Kgs.21.10", "Jude.1.4"]
         },
         {
           "Id": 29,
-          "References": ["Acts 13:45", "I John 3:12"]
+          "References": ["Acts.13.45", "1John.3.12"]
         },
         {
           "Id": 30,
-          "References": ["Psa. 1:1", "II Peter 3:3"]
+          "References": ["Ps.1.1", "2Pet.3.3"]
         },
         {
           "Id": 31,
-          "References": ["I Peter 4:4"]
+          "References": ["1Pet.4.4"]
         },
         {
           "Id": 32,
-          "References": ["Acts 4:18", "Acts 13:45-46, 50", "Acts 19:9", "I Thess 2:16", "Heb. 10:29"]
+          "References": ["Acts.4.18", "Acts.13.45-Acts.13.46,Acts.13.50", "Acts.19.9", "1Thess.2.16", "Heb.10.29"]
         },
         {
           "Id": 33,
-          "References": ["II Tim. 3:5", "Matt. 6:1-2, 5, 16", "Matt. 23:14"]
+          "References": ["2Tim.3.5", "Matt.6.1-Matt.6.2,Matt.6.5,Matt.6.16", "Matt.23.14"]
         },
         {
           "Id": 34,
-          "References": ["Mark 8:38"]
+          "References": ["Mark.8.38"]
         },
         {
           "Id": 35,
-          "References": ["Psa. 73:14-15"]
+          "References": ["Ps.73.14-Ps.73.15"]
         },
         {
           "Id": 36,
-          "References": ["I Cor. 6:5-6", "Eph. 5:15-17"]
+          "References": ["1Cor.6.5-1Cor.6.6", "Eph.5.15-Eph.5.17"]
         },
         {
           "Id": 37,
-          "References": ["Isa. 5:4", "II Peter 1:8-9"]
+          "References": ["Isa.5.4", "2Pet.1.8-2Pet.1.9"]
         },
         {
           "Id": 38,
-          "References": ["Rom. 2:23-24"]
+          "References": ["Rom.2.23-Rom.2.24"]
         },
         {
           "Id": 39,
-          "References": ["Gal. 3:1, 3", "Heb. 6:6"]
+          "References": ["Gal.3.1,Gal.3.3", "Heb.6.6"]
         }
       ]
     },
@@ -3389,19 +3389,19 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Exod. 20:7"]
+          "References": ["Exod.20.7"]
         },
         {
           "Id": 2,
-          "References": ["Lev. 19:12"]
+          "References": ["Lev.19.12"]
         },
         {
           "Id": 3,
-          "References": ["Ezek. 36:21-23", "Deut. 28:58-59", "Zech. 5:2-4"]
+          "References": ["Ezek.36.21-Ezek.36.23", "Deut.28.58-Deut.28.59", "Zech.5.2-Zech.5.4"]
         },
         {
           "Id": 4,
-          "References": ["I Sam. 2:12, 17, 22, 24", "I Sam. 3:18"]
+          "References": ["1Sam.2.12,1Sam.2.17,1Sam.2.22,1Sam.2.24", "1Sam.3.18"]
         }
       ]
     },
@@ -3413,7 +3413,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Exod. 20:8-11"]
+          "References": ["Exod.20.8-Exod.20.11"]
         }
       ]
     },
@@ -3425,11 +3425,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Deut. 5:12, 14, 18", "Gen. 2:2-3", "I Cor. 16:1-2", "Acts 20:7", "Matt. 5:17-18", "Isa. 56:2, 4, 6-7"]
+          "References": ["Deut.5.12,Deut.5.14,Deut.5.18", "Gen.2.2-Gen.2.3", "1Cor.16.1-1Cor.16.2", "Acts.20.7", "Matt.5.17-Matt.5.18", "Isa.56.2,Isa.56.4,Isa.56.6-Isa.56.7"]
         },
         {
           "Id": 2,
-          "References": ["Rev. 1:10"]
+          "References": ["Rev.1.10"]
         }
       ]
     },
@@ -3441,23 +3441,23 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Exod. 20:8, 10"]
+          "References": ["Exod.20.8,Exod.20.10"]
         },
         {
           "Id": 2,
-          "References": ["Exod. 16:25-28", "Neh. 13:15-22", "Jer. 17:21-22"]
+          "References": ["Exod.16.25-Exod.16.28", "Neh.13.15-Neh.13.22", "Jer.17.21-Jer.17.22"]
         },
         {
           "Id": 3,
-          "References": ["Matt. 12:1-13"]
+          "References": ["Matt.12.1-Matt.12.13"]
         },
         {
           "Id": 4,
-          "References": ["Isa. 58:13-14", "Isa. 66:23", "Luke 4:16", "Acts 20:7", "I Cor. 16:1-2", "Psa. ch. 92", "Lev. 23:3"]
+          "References": ["Isa.58.13-Isa.58.14", "Isa.66.23", "Luke.4.16", "Acts.20.7", "1Cor.16.1-1Cor.16.2", "Ps.92", "Lev.23.3"]
         },
         {
           "Id": 5,
-          "References": ["Exod. 16:22, 25-26, 29", "Exod. 20:8", "Luke 23:54, 56", "Neh. 13:19"]
+          "References": ["Exod.16.22,Exod.16.25-Exod.16.26,Exod.16.29", "Exod.20.8", "Luke.23.54,Luke.23.56", "Neh.13.19"]
         }
       ]
     },
@@ -3469,7 +3469,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Exod. 20:10", "Exod. 23:12", "Josh. 24:15", "Neh. 13:15, 17", "Jer. 17:20-22"]
+          "References": ["Exod.20.10", "Exod.23.12", "Josh.24.15", "Neh.13.15,Neh.13.17", "Jer.17.20-Jer.17.22"]
         }
       ]
     },
@@ -3481,19 +3481,19 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ezek. 22:26"]
+          "References": ["Ezek.22.26"]
         },
         {
           "Id": 2,
-          "References": ["Acts 15:7, 9", "Ezek. 33:30-32", "Amos 8:5", "Mal. 1:13"]
+          "References": ["Acts.15.7,Acts.15.9", "Ezek.33.30-Ezek.33.32", "Amos.8.5", "Mal.1.13"]
         },
         {
           "Id": 3,
-          "References": ["Ezek. 23:38"]
+          "References": ["Ezek.23.38"]
         },
         {
           "Id": 4,
-          "References": ["Jer. 17:24, 27", "Isa. 58:13"]
+          "References": ["Jer.17.24,Jer.17.27", "Isa.58.13"]
         }
       ]
     },
@@ -3505,15 +3505,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Exod. 20:9"]
+          "References": ["Exod.20.9"]
         },
         {
           "Id": 2,
-          "References": ["Exod. 20:10"]
+          "References": ["Exod.20.10"]
         },
         {
           "Id": 3,
-          "References": ["Exod. 20:11"]
+          "References": ["Exod.20.11"]
         }
       ]
     },
@@ -3525,39 +3525,39 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Exod. 20:8"]
+          "References": ["Exod.20.8"]
         },
         {
           "Id": 2,
-          "References": ["Exod. 16:23", "Luke 23:54, 56", "Mark 15:42", "Neh. 13:19"]
+          "References": ["Exod.16.23", "Luke.23.54,Luke.23.56", "Mark.15.42", "Neh.13.19"]
         },
         {
           "Id": 3,
-          "References": ["Psa. 92:13-14", "Ezek. 20:12, 19-20"]
+          "References": ["Ps.92.13-Ps.92.14", "Ezek.20.12,Ezek.20.19-Ezek.20.20"]
         },
         {
           "Id": 4,
-          "References": ["Gen. 2:2-3", "Psa. 118:22, 24", "Acts 4:10, 11", "Rev. 1:10"]
+          "References": ["Gen.2.2-Gen.2.3", "Ps.118.22,Ps.118.24", "Acts.4.10-Acts.4.11", "Rev.1.10"]
         },
         {
           "Id": 5,
-          "References": ["Ezek. 22:26"]
+          "References": ["Ezek.22.26"]
         },
         {
           "Id": 6,
-          "References": ["Neh. 9:14"]
+          "References": ["Neh.9.14"]
         },
         {
           "Id": 7,
-          "References": ["Exod. 34:21"]
+          "References": ["Exod.34.21"]
         },
         {
           "Id": 8,
-          "References": ["Deut. 5:14-15", "Amos 8:5"]
+          "References": ["Deut.5.14-Deut.5.15", "Amos.8.5"]
         },
         {
           "Id": 9,
-          "References": ["Lam. 1:7", "Jer. 17:21-23", "Neh. 13:15-23"]
+          "References": ["Lam.1.7", "Jer.17.21-Jer.17.23", "Neh.13.15-Neh.13.23"]
         }
       ]
     },
@@ -3569,11 +3569,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 22:39"]
+          "References": ["Matt.22.39"]
         },
         {
           "Id": 2,
-          "References": ["Matt. 7:12"]
+          "References": ["Matt.7.12"]
         }
       ]
     },
@@ -3585,7 +3585,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Exod. 20:12"]
+          "References": ["Exod.20.12"]
         }
       ]
     },
@@ -3597,27 +3597,27 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Prov. 23:22-25", "Eph. 6:1-2"]
+          "References": ["Prov.23.22-Prov.23.25", "Eph.6.1-Eph.6.2"]
         },
         {
           "Id": 2,
-          "References": ["I Tim. 5:1-2"]
+          "References": ["1Tim.5.1-1Tim.5.2"]
         },
         {
           "Id": 3,
-          "References": ["Gen. 4:20-22", "Gen. 45:8"]
+          "References": ["Gen.4.20-Gen.4.22", "Gen.45.8"]
         },
         {
           "Id": 4,
-          "References": ["II Kings 5:13"]
+          "References": ["2Kgs.5.13"]
         },
         {
           "Id": 5,
-          "References": ["II Kings 2:12", "II Kings 13:14", "Gal. 4:19"]
+          "References": ["2Kgs.2.12", "2Kgs.13.14", "Gal.4.19"]
         },
         {
           "Id": 6,
-          "References": ["Isa. 49:23"]
+          "References": ["Isa.49.23"]
         }
       ]
     },
@@ -3629,11 +3629,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Eph. 6:4", "II Cor. 12:14", "I Thess. 2:7-8, 11", "Num. 11:11-12"]
+          "References": ["Eph.6.4", "2Cor.12.14", "1Thess.2.7-1Thess.2.8,1Thess.2.11", "Num.11.11-Num.11.12"]
         },
         {
           "Id": 2,
-          "References": ["I Cor. 4:14-16", "II Kings 5:13"]
+          "References": ["1Cor.4.14-1Cor.4.16", "2Kgs.5.13"]
         }
       ]
     },
@@ -3645,7 +3645,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Eph. 5:21", "I Peter 2:17", "Rom. 12:10"]
+          "References": ["Eph.5.21", "1Pet.2.17", "Rom.12.10"]
         }
       ]
     },
@@ -3657,47 +3657,47 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Mal. 1:6", "Lev. 19:3"]
+          "References": ["Mal.1.6", "Lev.19.3"]
         },
         {
           "Id": 2,
-          "References": ["Prov. 31:28", "I Peter 3:6"]
+          "References": ["Prov.31.28", "1Pet.3.6"]
         },
         {
           "Id": 3,
-          "References": ["Lev. 19:32", "I Kings 2:19"]
+          "References": ["Lev.19.32", "1Kgs.2.19"]
         },
         {
           "Id": 4,
-          "References": ["I Tim. 2:1-2"]
+          "References": ["1Tim.2.1-1Tim.2.2"]
         },
         {
           "Id": 5,
-          "References": ["Heb. 13:7", "Phil. 3:17"]
+          "References": ["Heb.13.7", "Phil.3.17"]
         },
         {
           "Id": 6,
-          "References": ["Eph. 6:1-2, 5-7", "I Peter 2:13-14", "Rom. 13:1-5", "Heb. 13:17", "Prov. 4:3-4", "Prov. 23:22", "Exod. 18:19, 24"]
+          "References": ["Eph.6.1-Eph.6.2,Eph.6.5-Eph.6.7", "1Pet.2.13-1Pet.2.14", "Rom.13.1-Rom.13.5", "Heb.13.17", "Prov.4.3-Prov.4.4", "Prov.23.22", "Exod.18.19,Exod.18.24"]
         },
         {
           "Id": 7,
-          "References": ["Heb. 12:9", "I Peter 2:18-20"]
+          "References": ["Heb.12.9", "1Pet.2.18-1Pet.2.20"]
         },
         {
           "Id": 8,
-          "References": ["Titus 2:9-10"]
+          "References": ["Titus.2.9-Titus.2.10"]
         },
         {
           "Id": 9,
-          "References": ["I Sam. 26:15-16", "II Sam. 18:3", "Est.. 6:2"]
+          "References": ["1Sam.26.15-1Sam.26.16", "2Sam.18.3", "Esth.6.2"]
         },
         {
           "Id": 10,
-          "References": ["Matt. 22:21", "Rom. 13:6-7", "I Tim. 5:17-18", "Gal. 6:6", "Gen. 45:11", "Gen. 47:12"]
+          "References": ["Matt.22.21", "Rom.13.6-Rom.13.7", "1Tim.5.17-1Tim.5.18", "Gal.6.6", "Gen.45.11", "Gen.47.12"]
         },
         {
           "Id": 11,
-          "References": ["Psa. 127:3-5", "Prov. 31:23"]
+          "References": ["Ps.127.3-Ps.127.5", "Prov.31.23"]
         }
       ]
     },
@@ -3709,43 +3709,43 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 15:4-6"]
+          "References": ["Matt.15.4-Matt.15.6"]
         },
         {
           "Id": 2,
-          "References": ["Num. 11:28-29"]
+          "References": ["Num.11.28-Num.11.29"]
         },
         {
           "Id": 3,
-          "References": ["I Sam. 8:7", "Isa. 3:5"]
+          "References": ["1Sam.8.7", "Isa.3.5"]
         },
         {
           "Id": 4,
-          "References": ["II Sam. 15:1-12"]
+          "References": ["2Sam.15.1-2Sam.15.12"]
         },
         {
           "Id": 5,
-          "References": ["Exod. 21:15"]
+          "References": ["Exod.21.15"]
         },
         {
           "Id": 6,
-          "References": ["I Sam. 10:27"]
+          "References": ["1Sam.10.27"]
         },
         {
           "Id": 7,
-          "References": ["I Sam. 2:25"]
+          "References": ["1Sam.2.25"]
         },
         {
           "Id": 8,
-          "References": ["Deut. 21:18-21"]
+          "References": ["Deut.21.18-Deut.21.21"]
         },
         {
           "Id": 9,
-          "References": ["Prov. 30:11, 17"]
+          "References": ["Prov.30.11,Prov.30.17"]
         },
         {
           "Id": 10,
-          "References": ["Prov. 19:26"]
+          "References": ["Prov.19.26"]
         }
       ]
     },
@@ -3757,67 +3757,67 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Col. 3:19", "Titus 2:4"]
+          "References": ["Col.3.19", "Titus.2.4"]
         },
         {
           "Id": 2,
-          "References": ["I Sam. 12:23", "Job 1:5"]
+          "References": ["1Sam.12.23", "Job.1.5"]
         },
         {
           "Id": 3,
-          "References": ["I Kings 8:55-56", "Heb. 7:7", "Gen. 49:28"]
+          "References": ["1Kgs.8.55-1Kgs.8.56", "Heb.7.7", "Gen.49.28"]
         },
         {
           "Id": 4,
-          "References": ["Deut. 6:6-7"]
+          "References": ["Deut.6.6-Deut.6.7"]
         },
         {
           "Id": 5,
-          "References": ["Eph. 6:4"]
+          "References": ["Eph.6.4"]
         },
         {
           "Id": 6,
-          "References": ["I Peter 3:7"]
+          "References": ["1Pet.3.7"]
         },
         {
           "Id": 7,
-          "References": ["I Peter 2:14", "Rom. 13:3"]
+          "References": ["1Pet.2.14", "Rom.13.3"]
         },
         {
           "Id": 8,
-          "References": ["Esth. 6:3"]
+          "References": ["Esth.6.3"]
         },
         {
           "Id": 9,
-          "References": ["Rom. 13:3-4"]
+          "References": ["Rom.13.3-Rom.13.4"]
         },
         {
           "Id": 10,
-          "References": ["Prov. 29:15", "I Peter 2:14"]
+          "References": ["Prov.29.15", "1Pet.2.14"]
         },
         {
           "Id": 11,
-          "References": ["Job 29:12-17", "Isa. 1:10, 17"]
+          "References": ["Job.29.12-Job.29.17", "Isa.1.10,Isa.1.17"]
         },
         {
           "Id": 12,
-          "References": ["Eph. 6:4"]
+          "References": ["Eph.6.4"]
         },
         {
           "Id": 13,
-          "References": ["I Tim. 5:8"]
+          "References": ["1Tim.5.8"]
         },
         {
           "Id": 14,
-          "References": ["I Tim. 4:12", "Titus 2:3-5"]
+          "References": ["1Tim.4.12", "Titus.2.3-Titus.2.5"]
         },
         {
           "Id": 15,
-          "References": ["I Kings 3:28"]
+          "References": ["1Kgs.3.28"]
         },
         {
           "Id": 16,
-          "References": ["Titus 2:15"]
+          "References": ["Titus.2.15"]
         }
       ]
     },
@@ -3829,59 +3829,59 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Ezek. 34:2-4"]
+          "References": ["Ezek.34.2-Ezek.34.4"]
         },
         {
           "Id": 2,
-          "References": ["Phil. 2:21"]
+          "References": ["Phil.2.21"]
         },
         {
           "Id": 3,
-          "References": ["John 5:44", "John 7:18"]
+          "References": ["John.5.44", "John.7.18"]
         },
         {
           "Id": 4,
-          "References": ["Isa. 56:10-11", "Deut. 17:17"]
+          "References": ["Isa.56.10-Isa.56.11", "Deut.17.17"]
         },
         {
           "Id": 5,
-          "References": ["Dan. 3:4-6", "Acts 4:17-18"]
+          "References": ["Dan.3.4-Dan.3.6", "Acts.4.17-Acts.4.18"]
         },
         {
           "Id": 6,
-          "References": ["Exod. 5:10-18", "Matt. 23:2, 4"]
+          "References": ["Exod.5.10-Exod.5.18", "Matt.23.2,Matt.23.4"]
         },
         {
           "Id": 7,
-          "References": ["Matt. 14:8", "Mark 6:24"]
+          "References": ["Matt.14.8", "Mark.6.24"]
         },
         {
           "Id": 8,
-          "References": ["II Sam. 13:28"]
+          "References": ["2Sam.13.28"]
         },
         {
           "Id": 9,
-          "References": ["I Sam. 3:13"]
+          "References": ["1Sam.3.13"]
         },
         {
           "Id": 10,
-          "References": ["John 7:46-49", "Col. 3:21", "Exod. 5:17"]
+          "References": ["John.7.46-John.7.49", "Col.3.21", "Exod.5.17"]
         },
         {
           "Id": 11,
-          "References": ["I Peter 2:18-20", "Heb. 12:10", "Deut. 25:3"]
+          "References": ["1Pet.2.18-1Pet.2.20", "Heb.12.10", "Deut.25.3"]
         },
         {
           "Id": 12,
-          "References": ["Gen. 38:11, 26", "Acts 18:17"]
+          "References": ["Gen.38.11,Gen.38.26", "Acts.18.17"]
         },
         {
           "Id": 13,
-          "References": ["Eph. 6:4"]
+          "References": ["Eph.6.4"]
         },
         {
           "Id": 14,
-          "References": ["Gen. 9:21", "I Kings 1:6", "I Kings 12:13-16", "I Sam. 2:29-31"]
+          "References": ["Gen.9.21", "1Kgs.1.6", "1Kgs.12.13-1Kgs.12.16", "1Sam.2.29-1Sam.2.31"]
         }
       ]
     },
@@ -3893,15 +3893,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["I Peter 2:17"]
+          "References": ["1Pet.2.17"]
         },
         {
           "Id": 2,
-          "References": ["Rom. 12:10"]
+          "References": ["Rom.12.10"]
         },
         {
           "Id": 3,
-          "References": ["Rom. 12:15-16", "Phil. 2:3-4"]
+          "References": ["Rom.12.15-Rom.12.16", "Phil.2.3-Phil.2.4"]
         }
       ]
     },
@@ -3913,23 +3913,23 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Rom. 13:8"]
+          "References": ["Rom.13.8"]
         },
         {
           "Id": 2,
-          "References": ["II Tim. 3:3"]
+          "References": ["2Tim.3.3"]
         },
         {
           "Id": 3,
-          "References": ["Acts 7:9", "Gal. 5:26"]
+          "References": ["Acts.7.9", "Gal.5.26"]
         },
         {
           "Id": 4,
-          "References": ["Num. 12:2", "Est. 6:12-13"]
+          "References": ["Num.12.2", "Esth.6.12-Esth.6.13"]
         },
         {
           "Id": 5,
-          "References": ["III John 1:9", "Luke 22:24"]
+          "References": ["3John.1.9", "Luke.22.24"]
         }
       ]
     },
@@ -3941,11 +3941,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Exod. 20:12"]
+          "References": ["Exod.20.12"]
         },
         {
           "Id": 2,
-          "References": ["Deut. 5:16", "I Kings 8:25", "Eph. 6:2-3"]
+          "References": ["Deut.5.16", "1Kgs.8.25", "Eph.6.2-Eph.6.3"]
         }
       ]
     },
@@ -3957,7 +3957,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Exod. 20:13"]
+          "References": ["Exod.20.13"]
         }
       ]
     },
@@ -3969,103 +3969,103 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Eph. 5:28-29"]
+          "References": ["Eph.5.28-Eph.5.29"]
         },
         {
           "Id": 2,
-          "References": ["I Kings 18:4"]
+          "References": ["1Kgs.18.4"]
         },
         {
           "Id": 3,
-          "References": ["Jer. 26:15-16", "Acts 23:12, 16-17, 21, 27"]
+          "References": ["Jer.26.15-Jer.26.16", "Acts.23.12,Acts.23.16-Acts.23.17,Acts.23.21,Acts.23.27"]
         },
         {
           "Id": 4,
-          "References": ["Eph. 4:26-27"]
+          "References": ["Eph.4.26-Eph.4.27"]
         },
         {
           "Id": 5,
-          "References": ["II Sam. 2:22", "Deut. 22:8"]
+          "References": ["2Sam.2.22", "Deut.22.8"]
         },
         {
           "Id": 6,
-          "References": ["Matt. 4:6-7", "Prov. 1:10-11, 15-16"]
+          "References": ["Matt.4.6-Matt.4.7", "Prov.1.10-Prov.1.11,Prov.1.15-Prov.1.16"]
         },
         {
           "Id": 7,
-          "References": ["I Sam. 24:2", "I Sam. 26:9-11", "Gen. 37:21-22"]
+          "References": ["1Sam.24.2", "1Sam.26.9-1Sam.26.11", "Gen.37.21-Gen.37.22"]
         },
         {
           "Id": 8,
-          "References": ["Psa. 82:4", "Prov. 24:11-12", "I Sam. 14:45"]
+          "References": ["Ps.82.4", "Prov.24.11-Prov.24.12", "1Sam.14.45"]
         },
         {
           "Id": 9,
-          "References": ["James 5:7-11", "Heb. 12:9"]
+          "References": ["Jas.5.7-Jas.5.11", "Heb.12.9"]
         },
         {
           "Id": 10,
-          "References": ["I Thess. 4:11", "I Peter 3:3-4", "Psa. 37:8-11"]
+          "References": ["1Thess.4.11", "1Pet.3.3-1Pet.3.4", "Ps.37.8-Ps.37.11"]
         },
         {
           "Id": 11,
-          "References": ["Prov. 17:22"]
+          "References": ["Prov.17.22"]
         },
         {
           "Id": 12,
-          "References": ["Prov. 25:16, 27"]
+          "References": ["Prov.25.16,Prov.25.27"]
         },
         {
           "Id": 13,
-          "References": ["I Tim. 5:23"]
+          "References": ["1Tim.5.23"]
         },
         {
           "Id": 14,
-          "References": ["Isa. 38:21"]
+          "References": ["Isa.38.21"]
         },
         {
           "Id": 15,
-          "References": ["Psa. 127:2"]
+          "References": ["Ps.127.2"]
         },
         {
           "Id": 16,
-          "References": ["Eccl. 5:12", "II Thess. 3:10, 12", "Prov. 16:26"]
+          "References": ["Eccl.5.12", "2Thess.3.10,2Thess.3.12", "Prov.16.26"]
         },
         {
           "Id": 17,
-          "References": ["Eccl. 3:4, 11"]
+          "References": ["Eccl.3.4,Eccl.3.11"]
         },
         {
           "Id": 18,
-          "References": ["I Sam. 19:4-5", "I Sam. 22:13-14"]
+          "References": ["1Sam.19.4-1Sam.19.5", "1Sam.22.13-1Sam.22.14"]
         },
         {
           "Id": 19,
-          "References": ["Rom. 13:10"]
+          "References": ["Rom.13.10"]
         },
         {
           "Id": 20,
-          "References": ["Luke 10:33-34"]
+          "References": ["Luke.10.33-Luke.10.34"]
         },
         {
           "Id": 21,
-          "References": ["Col. 3:12-13"]
+          "References": ["Col.3.12-Col.3.13"]
         },
         {
           "Id": 22,
-          "References": ["James 3:17"]
+          "References": ["Jas.3.17"]
         },
         {
           "Id": 23,
-          "References": ["I Peter 3:8-11", "Prov. 15:1", "Judg. 8:1-3"]
+          "References": ["1Pet.3.8-1Pet.3.11", "Prov.15.1", "Judg.8.1-Judg.8.3"]
         },
         {
           "Id": 24,
-          "References": ["Matt. 5:24", "Eph. 4:2, 32", "Rom. 12:17, 20-21"]
+          "References": ["Matt.5.24", "Eph.4.2,Eph.4.32", "Rom.12.17,Rom.12.20-Rom.12.21"]
         },
         {
           "Id": 25,
-          "References": ["I Thess. 5:14", "Job 31:19-20", "Matt. 25:35-36", "Prov. 31:8-9"]
+          "References": ["1Thess.5.14", "Job.31.19-Job.31.20", "Matt.25.35-Matt.25.36", "Prov.31.8-Prov.31.9"]
         }
       ]
     },
@@ -4077,83 +4077,83 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Acts 16:28"]
+          "References": ["Acts.16.28"]
         },
         {
           "Id": 2,
-          "References": ["Gen. 9:6"]
+          "References": ["Gen.9.6"]
         },
         {
           "Id": 3,
-          "References": ["Num. 35:31, 33"]
+          "References": ["Num.35.31,Num.35.33"]
         },
         {
           "Id": 4,
-          "References": ["Jer. 48:10", "Deut. ch. 20"]
+          "References": ["Jer.48.10", "Deut.20"]
         },
         {
           "Id": 5,
-          "References": ["Exod. 22:2-3"]
+          "References": ["Exod.22.2-Exod.22.3"]
         },
         {
           "Id": 6,
-          "References": ["Matt. 25:42-43", "James 2:15-16", "Eccl. 6:1-2"]
+          "References": ["Matt.25.42-Matt.25.43", "Jas.2.15-Jas.2.16", "Eccl.6.1-Eccl.6.2"]
         },
         {
           "Id": 7,
-          "References": ["Matt. 5:22"]
+          "References": ["Matt.5.22"]
         },
         {
           "Id": 8,
-          "References": ["I John 3:15", "Lev. 19:17"]
+          "References": ["1John.3.15", "Lev.19.17"]
         },
         {
           "Id": 9,
-          "References": ["Prov. 14:30"]
+          "References": ["Prov.14.30"]
         },
         {
           "Id": 10,
-          "References": ["Rom. 12:19"]
+          "References": ["Rom.12.19"]
         },
         {
           "Id": 11,
-          "References": ["Eph. 4:31"]
+          "References": ["Eph.4.31"]
         },
         {
           "Id": 12,
-          "References": ["Matt. 6:31, 34"]
+          "References": ["Matt.6.31,Matt.6.34"]
         },
         {
           "Id": 13,
-          "References": ["Luke 21:34", "Rom. 13:13"]
+          "References": ["Luke.21.34", "Rom.13.13"]
         },
         {
           "Id": 14,
-          "References": ["Eccl. 2:22-23", "Eccl. 12:12"]
+          "References": ["Eccl.2.22-Eccl.2.23", "Eccl.12.12"]
         },
         {
           "Id": 15,
-          "References": ["Isa. 5:12"]
+          "References": ["Isa.5.12"]
         },
         {
           "Id": 16,
-          "References": ["Prov. 12:18", "Prov. 15:1"]
+          "References": ["Prov.12.18", "Prov.15.1"]
         },
         {
           "Id": 17,
-          "References": ["Ezek. 18:18", "Exod. 1:14"]
+          "References": ["Ezek.18.18", "Exod.1.14"]
         },
         {
           "Id": 18,
-          "References": ["Gal. 5:15", "Prov. 23:29"]
+          "References": ["Gal.5.15", "Prov.23.29"]
         },
         {
           "Id": 19,
-          "References": ["Num. 35:16-18, 21"]
+          "References": ["Num.35.16-Num.35.18,Num.35.21"]
         },
         {
           "Id": 20,
-          "References": ["Exod. 21:18-36"]
+          "References": ["Exod.21.18-Exod.21.36"]
         }
       ]
     },
@@ -4165,7 +4165,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Exod. 20:14"]
+          "References": ["Exod.20.14"]
         }
       ]
     },
@@ -4177,55 +4177,55 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["I Thess. 4:4", "Job 31:1", "I Cor. 7:34"]
+          "References": ["1Thess.4.4", "Job.31.1", "1Cor.7.34"]
         },
         {
           "Id": 2,
-          "References": ["Col. 4:6"]
+          "References": ["Col.4.6"]
         },
         {
           "Id": 3,
-          "References": ["I Peter 2:3"]
+          "References": ["1Pet.2.3"]
         },
         {
           "Id": 4,
-          "References": ["I Cor. 7:2, 35-36"]
+          "References": ["1Cor.7.2,1Cor.7.35-1Cor.7.36"]
         },
         {
           "Id": 5,
-          "References": ["Job 31:1"]
+          "References": ["Job.31.1"]
         },
         {
           "Id": 6,
-          "References": ["Acts 24:24"]
+          "References": ["Acts.24.24"]
         },
         {
           "Id": 7,
-          "References": ["Prov. 2:16-20"]
+          "References": ["Prov.2.16-Prov.2.20"]
         },
         {
           "Id": 8,
-          "References": ["I Tim. 2:9"]
+          "References": ["1Tim.2.9"]
         },
         {
           "Id": 9,
-          "References": ["I Cor. 7:2, 9"]
+          "References": ["1Cor.7.2,1Cor.7.9"]
         },
         {
           "Id": 10,
-          "References": ["Prov. 5:19-20"]
+          "References": ["Prov.5.19-Prov.5.20"]
         },
         {
           "Id": 11,
-          "References": ["I Peter 3:7"]
+          "References": ["1Pet.3.7"]
         },
         {
           "Id": 12,
-          "References": ["Prov. 31:11, 27-28"]
+          "References": ["Prov.31.11,Prov.31.27-Prov.31.28"]
         },
         {
           "Id": 13,
-          "References": ["Prov. 5:8", "Gen. 39:8-10"]
+          "References": ["Prov.5.8", "Gen.39.8-Gen.39.10"]
         }
       ]
     },
@@ -4237,83 +4237,83 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Prov. 5:7"]
+          "References": ["Prov.5.7"]
         },
         {
           "Id": 2,
-          "References": ["Heb. 13:4", "Gal. 5:19"]
+          "References": ["Heb.13.4", "Gal.5.19"]
         },
         {
           "Id": 3,
-          "References": ["II Sam. 13:14", "I Cor. 5:1"]
+          "References": ["2Sam.13.14", "1Cor.5.1"]
         },
         {
           "Id": 4,
-          "References": ["Rom. 1:24, 26-27", "Lev. 20:15-16"]
+          "References": ["Rom.1.24,Rom.1.26-Rom.1.27", "Lev.20.15-Lev.20.16"]
         },
         {
           "Id": 5,
-          "References": ["Matt. 5:28", "Matt. 15:19", "Col. 3:5"]
+          "References": ["Matt.5.28", "Matt.15.19", "Col.3.5"]
         },
         {
           "Id": 6,
-          "References": ["Eph. 5:3-4", "Prov. 7:5, 21-22"]
+          "References": ["Eph.5.3-Eph.5.4", "Prov.7.5,Prov.7.21-Prov.7.22"]
         },
         {
           "Id": 7,
-          "References": ["Isa. 3:16", "II Peter 2:14"]
+          "References": ["Isa.3.16", "2Pet.2.14"]
         },
         {
           "Id": 8,
-          "References": ["Prov. 7:10, 13"]
+          "References": ["Prov.7.10,Prov.7.13"]
         },
         {
           "Id": 9,
-          "References": ["I Tim. 4:3"]
+          "References": ["1Tim.4.3"]
         },
         {
           "Id": 10,
-          "References": ["Lev. 18:1-21", "Mark 6:18", "Mal. 2:11-12"]
+          "References": ["Lev.18.1-Lev.18.21", "Mark.6.18", "Mal.2.11-Mal.2.12"]
         },
         {
           "Id": 11,
-          "References": ["I Kings 15:12", "II Kings 23:7", "Deut. 23:17-18", "Lev. 19:29", "Jer. 5:7", "Prov. 7:24-27"]
+          "References": ["1Kgs.15.12", "2Kgs.23.7", "Deut.23.17-Deut.23.18", "Lev.19.29", "Jer.5.7", "Prov.7.24-Prov.7.27"]
         },
         {
           "Id": 12,
-          "References": ["Matt. 19:10-11"]
+          "References": ["Matt.19.10-Matt.19.11"]
         },
         {
           "Id": 13,
-          "References": ["I Cor. 7:7-9", "Gen. 38:26"]
+          "References": ["1Cor.7.7-1Cor.7.9", "Gen.38.26"]
         },
         {
           "Id": 14,
-          "References": ["Mal. 2:14-15", "Matt. 19:5"]
+          "References": ["Mal.2.14-Mal.2.15", "Matt.19.5"]
         },
         {
           "Id": 15,
-          "References": ["Mal. 2:16", "Matt. 5:32"]
+          "References": ["Mal.2.16", "Matt.5.32"]
         },
         {
           "Id": 16,
-          "References": ["I Cor. 7:12-13"]
+          "References": ["1Cor.7.12-1Cor.7.13"]
         },
         {
           "Id": 17,
-          "References": ["Ezek. 16:49", "Prov. 23:30-33"]
+          "References": ["Ezek.16.49", "Prov.23.30-Prov.23.33"]
         },
         {
           "Id": 18,
-          "References": ["Gen. 39:10", "Prov. 5:8"]
+          "References": ["Gen.39.10", "Prov.5.8"]
         },
         {
           "Id": 19,
-          "References": ["Eph. 5:4", "Ezek. 23:14-16", "Isa. 3:16", "Isa. 23:15-17", "Mark 6:22", "Rom. 13:13", "I Peter 4:3"]
+          "References": ["Eph.5.4", "Ezek.23.14-Ezek.23.16", "Isa.3.16", "Isa.23.15-Isa.23.17", "Mark.6.22", "Rom.13.13", "1Pet.4.3"]
         },
         {
           "Id": 20,
-          "References": ["II Kings 9:30", "Jer. 4:30", "Ezek. 23:40"]
+          "References": ["2Kgs.9.30", "Jer.4.30", "Ezek.23.40"]
         }
       ]
     },
@@ -4325,7 +4325,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Exod. 20:15"]
+          "References": ["Exod.20.15"]
         }
       ]
     },
@@ -4337,55 +4337,55 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Psa. 15:2, 4", "Zech. 7:4, 10", "Zech. 8:16-17"]
+          "References": ["Ps.15.2,Ps.15.4", "Zech.7.4,Zech.7.10", "Zech.8.16-Zech.8.17"]
         },
         {
           "Id": 2,
-          "References": ["Rom. 13:7"]
+          "References": ["Rom.13.7"]
         },
         {
           "Id": 3,
-          "References": ["Lev. 6:2-5", "Luke 19:8"]
+          "References": ["Lev.6.2-Lev.6.5", "Luke.19.8"]
         },
         {
           "Id": 4,
-          "References": ["Luke 6:30, 38", "I John 3:17", "Eph. 4:28", "Gal. 6:10"]
+          "References": ["Luke.6.30,Luke.6.38", "1John.3.17", "Eph.4.28", "Gal.6.10"]
         },
         {
           "Id": 5,
-          "References": ["I Tim. 6:6-9", "Gal. 6:14"]
+          "References": ["1Tim.6.6-1Tim.6.9", "Gal.6.14"]
         },
         {
           "Id": 6,
-          "References": ["I Tim. 5:8"]
+          "References": ["1Tim.5.8"]
         },
         {
           "Id": 7,
-          "References": ["Prov. 27:23-27", "Eccl. 2:24", "Eccl. 3:12-13", "I Tim. 6:17-18", "Isa. 38:1", "Matt. 11:8"]
+          "References": ["Prov.27.23-Prov.27.27", "Eccl.2.24", "Eccl.3.12-Eccl.3.13", "1Tim.6.17-1Tim.6.18", "Isa.38.1", "Matt.11.8"]
         },
         {
           "Id": 8,
-          "References": ["I Cor. 7:20", "Gen. 2:15, 3:19"]
+          "References": ["1Cor.7.20", "Gen.2.15,Gen.3.19"]
         },
         {
           "Id": 9,
-          "References": ["Eph. 4:28", "Prov. 10:4"]
+          "References": ["Eph.4.28", "Prov.10.4"]
         },
         {
           "Id": 10,
-          "References": ["John 6:12", "Prov. 21:20"]
+          "References": ["John.6.12", "Prov.21.20"]
         },
         {
           "Id": 11,
-          "References": ["I Cor. 6:1-9"]
+          "References": ["1Cor.6.1-1Cor.6.9"]
         },
         {
           "Id": 12,
-          "References": ["Prov. 6:1-6", "Prov. 11:15"]
+          "References": ["Prov.6.1-Prov.6.6", "Prov.11.15"]
         },
         {
           "Id": 13,
-          "References": ["Lev. 25:35", "Deut. 22:1-4", "Exod. 23:4-5", "Gen. 47:14, 20", "Phil. 2:4, Matt. 22:39"]
+          "References": ["Lev.25.35", "Deut.22.1-Deut.22.4", "Exod.23.4-Exod.23.5", "Gen.47.14,Gen.47.20", "Phil.2.4,Matt.22.39"]
         }
       ]
     },
@@ -4397,107 +4397,107 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["James 2:15-16", "I John 3:17"]
+          "References": ["Jas.2.15-Jas.2.16", "1John.3.17"]
         },
         {
           "Id": 2,
-          "References": ["Eph. 4:28", "Psa. 42:10"]
+          "References": ["Eph.4.28", "Ps.42.10"]
         },
         {
           "Id": 3,
-          "References": ["Psa. 62:10"]
+          "References": ["Ps.62.10"]
         },
         {
           "Id": 4,
-          "References": ["I Tim. 1:10"]
+          "References": ["1Tim.1.10"]
         },
         {
           "Id": 5,
-          "References": ["Prov. 29:24", "Psa. 50:18"]
+          "References": ["Prov.29.24", "Ps.50.18"]
         },
         {
           "Id": 6,
-          "References": ["I Thess. 4:6"]
+          "References": ["1Thess.4.6"]
         },
         {
           "Id": 7,
-          "References": ["Prov. 11:1", "Prov. 20:10"]
+          "References": ["Prov.11.1", "Prov.20.10"]
         },
         {
           "Id": 8,
-          "References": ["Deut. 19:14", "Prov. 23:10"]
+          "References": ["Deut.19.14", "Prov.23.10"]
         },
         {
           "Id": 9,
-          "References": ["Amos 8:5", "Psa. 37:21"]
+          "References": ["Amos.8.5", "Ps.37.21"]
         },
         {
           "Id": 10,
-          "References": ["Luke 16:10-12"]
+          "References": ["Luke.16.10-Luke.16.12"]
         },
         {
           "Id": 11,
-          "References": ["Ezek. 22:29", "Lev. 25:17"]
+          "References": ["Ezek.22.29", "Lev.25.17"]
         },
         {
           "Id": 12,
-          "References": ["Matt. 23:25", "Ezek. 22:12"]
+          "References": ["Matt.23.25", "Ezek.22.12"]
         },
         {
           "Id": 13,
-          "References": ["Psa. 15:5"]
+          "References": ["Ps.15.5"]
         },
         {
           "Id": 14,
-          "References": ["Job 15:34"]
+          "References": ["Job.15.34"]
         },
         {
           "Id": 15,
-          "References": ["I Cor. 6:6-8", "Prov. 3:29-30"]
+          "References": ["1Cor.6.6-1Cor.6.8", "Prov.3.29-Prov.3.30"]
         },
         {
           "Id": 16,
-          "References": ["Isa. 5:8", "Micah 2:2"]
+          "References": ["Isa.5.8", "Mic.2.2"]
         },
         {
           "Id": 17,
-          "References": ["Prov. 11:26"]
+          "References": ["Prov.11.26"]
         },
         {
           "Id": 18,
-          "References": ["Acts 19:19, 24-25"]
+          "References": ["Acts.19.19,Acts.19.24-Acts.19.25"]
         },
         {
           "Id": 19,
-          "References": ["Job. 20:19", "James 5:4", "Prov. 21:6"]
+          "References": ["Job.20.19", "Jas.5.4", "Prov.21.6"]
         },
         {
           "Id": 20,
-          "References": ["Luke 12:15"]
+          "References": ["Luke.12.15"]
         },
         {
           "Id": 21,
-          "References": ["I Tim. 6:5", "Col. 3:2", "Prov. 23:5", "Psa. 42:10"]
+          "References": ["1Tim.6.5", "Col.3.2", "Prov.23.5", "Ps.42.10"]
         },
         {
           "Id": 22,
-          "References": ["Matt. 6:25, 31, 34, Eccl. 5:12"]
+          "References": ["Matt.6.25,Matt.6.31,Matt.6.34,Eccl.5.12"]
         },
         {
           "Id": 23,
-          "References": ["Psa. 37:1, 7", "Psa. 73:3"]
+          "References": ["Ps.37.1,Ps.37.7", "Ps.73.3"]
         },
         {
           "Id": 24,
-          "References": ["II Thess. 3:11", "Prov. 18:9"]
+          "References": ["2Thess.3.11", "Prov.18.9"]
         },
         {
           "Id": 25,
-          "References": ["Prov. 21:17", "Prov. 23:20-21", "Prov. 28:19"]
+          "References": ["Prov.21.17", "Prov.23.20-Prov.23.21", "Prov.28.19"]
         },
         {
           "Id": 26,
-          "References": ["Eccl. 4:8", "Eccl. 6:2", "I Tim. 5:8"]
+          "References": ["Eccl.4.8", "Eccl.6.2", "1Tim.5.8"]
         }
       ]
     },
@@ -4509,7 +4509,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Exod. 20:16"]
+          "References": ["Exod.20.16"]
         }
       ]
     },
@@ -4521,99 +4521,99 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Zech. 8:16"]
+          "References": ["Zech.8.16"]
         },
         {
           "Id": 2,
-          "References": ["III John 1:12"]
+          "References": ["3John.1.12"]
         },
         {
           "Id": 3,
-          "References": ["Prov. 31:8-9"]
+          "References": ["Prov.31.8-Prov.31.9"]
         },
         {
           "Id": 4,
-          "References": ["Psa. 15:2"]
+          "References": ["Ps.15.2"]
         },
         {
           "Id": 5,
-          "References": ["II Chr. 19:9"]
+          "References": ["2Chr.19.9"]
         },
         {
           "Id": 6,
-          "References": ["I Sam. 19:4-5"]
+          "References": ["1Sam.19.4-1Sam.19.5"]
         },
         {
           "Id": 7,
-          "References": ["Josh. 7:19"]
+          "References": ["Josh.7.19"]
         },
         {
           "Id": 8,
-          "References": ["II Sam. 14:18-20"]
+          "References": ["2Sam.14.18-2Sam.14.20"]
         },
         {
           "Id": 9,
-          "References": ["Lev. 19:15", "Prov. 14:5, 25"]
+          "References": ["Lev.19.15", "Prov.14.5,Prov.14.25"]
         },
         {
           "Id": 10,
-          "References": ["II Cor. 1:17-18", "Eph. 4:25"]
+          "References": ["2Cor.1.17-2Cor.1.18", "Eph.4.25"]
         },
         {
           "Id": 11,
-          "References": ["Heb. 6:9", "I Cor. 13:7"]
+          "References": ["Heb.6.9", "1Cor.13.7"]
         },
         {
           "Id": 12,
-          "References": ["Rom. 1:8", "II John 1:4", "III John 1:3-4"]
+          "References": ["Rom.1.8", "2John.1.4", "3John.1.3-3John.1.4"]
         },
         {
           "Id": 13,
-          "References": ["II Cor. 2:4", "II Cor. 12:21"]
+          "References": ["2Cor.2.4", "2Cor.12.21"]
         },
         {
           "Id": 14,
-          "References": ["Prov. 17:9", "I Peter 4:8"]
+          "References": ["Prov.17.9", "1Pet.4.8"]
         },
         {
           "Id": 15,
-          "References": ["I Cor. 1:4-5, 7", "II Tim. 1:4-5"]
+          "References": ["1Cor.1.4-1Cor.1.5,1Cor.1.7", "2Tim.1.4-2Tim.1.5"]
         },
         {
           "Id": 16,
-          "References": ["I Sam. 22:14"]
+          "References": ["1Sam.22.14"]
         },
         {
           "Id": 17,
-          "References": ["I Cor. 13:6-7"]
+          "References": ["1Cor.13.6-1Cor.13.7"]
         },
         {
           "Id": 18,
-          "References": ["Psa. 15:3"]
+          "References": ["Ps.15.3"]
         },
         {
           "Id": 19,
-          "References": ["Prov. 25:23"]
+          "References": ["Prov.25.23"]
         },
         {
           "Id": 20,
-          "References": ["Prov. 26:24-25"]
+          "References": ["Prov.26.24-Prov.26.25"]
         },
         {
           "Id": 21,
-          "References": ["Psa. 101:5"]
+          "References": ["Ps.101.5"]
         },
         {
           "Id": 22,
-          "References": ["Prov. 22:1", "John 8:49"]
+          "References": ["Prov.22.1", "John.8.49"]
         },
         {
           "Id": 23,
-          "References": ["Psa. 15:4"]
+          "References": ["Ps.15.4"]
         },
         {
           "Id": 24,
-          "References": ["Phil. 4:8"]
+          "References": ["Phil.4.8"]
         }
       ]
     },
@@ -4625,191 +4625,191 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["I Sam. 17:28", "II Sam. 1:9-10, 15-16", "II Sam. 16:3"]
+          "References": ["1Sam.17.28", "2Sam.1.9-2Sam.1.10,2Sam.1.15-2Sam.1.16", "2Sam.16.3"]
         },
         {
           "Id": 2,
-          "References": ["Lev. 19:15", "Hab. 1:4"]
+          "References": ["Lev.19.15", "Hab.1.4"]
         },
         {
           "Id": 3,
-          "References": ["Prov. 6:16, 19", "Prov. 19:5"]
+          "References": ["Prov.6.16,Prov.6.19", "Prov.19.5"]
         },
         {
           "Id": 4,
-          "References": ["Acts 6:13"]
+          "References": ["Acts.6.13"]
         },
         {
           "Id": 5,
-          "References": ["Jer. 9:3, 5", "Acts 24:2, 5", "Psa. 3:1-4", "Psa. 12:3-4"]
+          "References": ["Jer.9.3,Jer.9.5", "Acts.24.2,Acts.24.5", "Ps.3.1-Ps.3.4", "Ps.12.3-Ps.12.4"]
         },
         {
           "Id": 6,
-          "References": ["Prov. 17:15", "I Kings 21:9-14"]
+          "References": ["Prov.17.15", "1Kgs.21.9-1Kgs.21.14"]
         },
         {
           "Id": 7,
-          "References": ["Isa. 5:23"]
+          "References": ["Isa.5.23"]
         },
         {
           "Id": 8,
-          "References": ["Psa. 119:69", "Luke 16:5-7", "Luke 19:8"]
+          "References": ["Ps.119.69", "Luke.16.5-Luke.16.7", "Luke.19.8"]
         },
         {
           "Id": 9,
-          "References": ["Lev. 5:1", "Acts 5:3, 8-9", "II Tim. 4:6"]
+          "References": ["Lev.5.1", "Acts.5.3,Acts.5.8-Acts.5.9", "2Tim.4.6"]
         },
         {
           "Id": 10,
-          "References": ["I Kings 1:6", "Lev. 19:17"]
+          "References": ["1Kgs.1.6", "Lev.19.17"]
         },
         {
           "Id": 11,
-          "References": ["Isa. 59:4"]
+          "References": ["Isa.59.4"]
         },
         {
           "Id": 12,
-          "References": ["Prov. 29:11"]
+          "References": ["Prov.29.11"]
         },
         {
           "Id": 13,
-          "References": ["I Sam. 22:9-10", "Psa. 52:1"]
+          "References": ["1Sam.22.9-1Sam.22.10", "Ps.52.1"]
         },
         {
           "Id": 14,
-          "References": ["Psa. 56:5", "John 2:19", "Matt. 26:60-61"]
+          "References": ["Ps.56.5", "John.2.19", "Matt.26.60-Matt.26.61"]
         },
         {
           "Id": 15,
-          "References": ["Gen. 3:5, 26:7, 9"]
+          "References": ["Gen.3.5,Gen.26.7,Gen.26.9"]
         },
         {
           "Id": 16,
-          "References": ["Isa. 59:13"]
+          "References": ["Isa.59.13"]
         },
         {
           "Id": 17,
-          "References": ["Lev. 19:11", "Col. 3:9"]
+          "References": ["Lev.19.11", "Col.3.9"]
         },
         {
           "Id": 18,
-          "References": ["Psa. 50:20"]
+          "References": ["Ps.50.20"]
         },
         {
           "Id": 19,
-          "References": ["Psa. 15:3"]
+          "References": ["Ps.15.3"]
         },
         {
           "Id": 20,
-          "References": ["James 4:11", "Jer. 38:4"]
+          "References": ["Jas.4.11", "Jer.38.4"]
         },
         {
           "Id": 21,
-          "References": ["Lev. 19:16"]
+          "References": ["Lev.19.16"]
         },
         {
           "Id": 22,
-          "References": ["Rom. 1:29-30"]
+          "References": ["Rom.1.29-Rom.1.30"]
         },
         {
           "Id": 23,
-          "References": ["Gen. 21:9", "Gal. 4:29"]
+          "References": ["Gen.21.9", "Gal.4.29"]
         },
         {
           "Id": 24,
-          "References": ["I Cor. 6:10"]
+          "References": ["1Cor.6.10"]
         },
         {
           "Id": 25,
-          "References": ["Mattt. 7:1"]
+          "References": ["Matt.7.1"]
         },
         {
           "Id": 26,
-          "References": ["Acts 28:4"]
+          "References": ["Acts.28.4"]
         },
         {
           "Id": 27,
-          "References": ["Gen. 38:24", "Rom. 2:1"]
+          "References": ["Gen.38.24", "Rom.2.1"]
         },
         {
           "Id": 28,
-          "References": ["Neh. 6:6-8", "Rom. 3:8", "Psa. 69:10", "I Sam. 1:13-15", "II Sam. 10:3"]
+          "References": ["Neh.6.6-Neh.6.8", "Rom.3.8", "Ps.69.10", "1Sam.1.13-1Sam.1.15", "2Sam.10.3"]
         },
         {
           "Id": 29,
-          "References": ["Psa. 12:2-3"]
+          "References": ["Ps.12.2-Ps.12.3"]
         },
         {
           "Id": 30,
-          "References": ["II Tim. 3:2"]
+          "References": ["2Tim.3.2"]
         },
         {
           "Id": 31,
-          "References": ["Luke 18:9, 11", "Rom. 12:16", "I Cor. 4:6", "Acts 12:22", "Exod. 4:10-14"]
+          "References": ["Luke.18.9,Luke.18.11", "Rom.12.16", "1Cor.4.6", "Acts.12.22", "Exod.4.10-Exod.4.14"]
         },
         {
           "Id": 32,
-          "References": ["Job 4:6, 27:5-6"]
+          "References": ["Job.4.6,Job.27.5-Job.27.6"]
         },
         {
           "Id": 33,
-          "References": ["Matt. 7:3-5"]
+          "References": ["Matt.7.3-Matt.7.5"]
         },
         {
           "Id": 34,
-          "References": ["Prov. 28:13", "Prov. 30:20", "Gen. 3:12-13", "Gen. 4:9", "Jer. 2:35", "II Kings 5:25"]
+          "References": ["Prov.28.13", "Prov.30.20", "Gen.3.12-Gen.3.13", "Gen.4.9", "Jer.2.35", "2Kgs.5.25"]
         },
         {
           "Id": 35,
-          "References": ["Gen. 9:22", "Prov. 25:9-10"]
+          "References": ["Gen.9.22", "Prov.25.9-Prov.25.10"]
         },
         {
           "Id": 36,
-          "References": ["Exod. 23:1"]
+          "References": ["Exod.23.1"]
         },
         {
           "Id": 37,
-          "References": ["Prov. 29:12"]
+          "References": ["Prov.29.12"]
         },
         {
           "Id": 38,
-          "References": ["Acts 7:56-57", "Job 31:13-14"]
+          "References": ["Acts.7.56-Acts.7.57", "Job.31.13-Job.31.14"]
         },
         {
           "Id": 39,
-          "References": ["I Cor. 13:5", "I Tim. 6:4"]
+          "References": ["1Cor.13.5", "1Tim.6.4"]
         },
         {
           "Id": 40,
-          "References": ["Num. 11:29", "Matt. 21:15"]
+          "References": ["Num.11.29", "Matt.21.15"]
         },
         {
           "Id": 41,
-          "References": ["Ezra 4:12-13"]
+          "References": ["Ezra.4.12-Ezra.4.13"]
         },
         {
           "Id": 42,
-          "References": ["Jer. 48:27"]
+          "References": ["Jer.48.27"]
         },
         {
           "Id": 43,
-          "References": ["Psa. 35:15-16, 21", "Matt. 27:28-29"]
+          "References": ["Ps.35.15-Ps.35.16,Ps.35.21", "Matt.27.28-Matt.27.29"]
         },
         {
           "Id": 44,
-          "References": ["Jude 1:16", "Acts 12:22"]
+          "References": ["Jude.1.16", "Acts.12.22"]
         },
         {
           "Id": 45,
-          "References": ["Rom. 1:31", "II Tim. 3:3"]
+          "References": ["Rom.1.31", "2Tim.3.3"]
         },
         {
           "Id": 46,
-          "References": ["I Sam. 2:24"]
+          "References": ["1Sam.2.24"]
         },
         {
           "Id": 47,
-          "References": ["II Sam. 13:12-13", "Prov. 5:8-9", "Prov. 6:33"]
+          "References": ["2Sam.13.12-2Sam.13.13", "Prov.5.8-Prov.5.9", "Prov.6.33"]
         }
       ]
     },
@@ -4821,7 +4821,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Exod. 20:17"]
+          "References": ["Exod.20.17"]
         }
       ]
     },
@@ -4833,11 +4833,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Heb. 13:5", "I Tim. 6:6"]
+          "References": ["Heb.13.5", "1Tim.6.6"]
         },
         {
           "Id": 2,
-          "References": ["Job 31:29", "Psa. 122:7-9", "I Tim. 1:5", "Est. 10:3", "I Cor. 13:4-7"]
+          "References": ["Job.31.29", "Ps.122.7-Ps.122.9", "1Tim.1.5", "Esth.10.3", "1Cor.13.4-1Cor.13.7"]
         }
       ]
     },
@@ -4849,19 +4849,19 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["I Kings 21:4", "Est. 5:13", "I Cor. 10:10"]
+          "References": ["1Kgs.21.4", "Esth.5.13", "1Cor.10.10"]
         },
         {
           "Id": 2,
-          "References": ["Gal. 5:26", "James 3:14, 16"]
+          "References": ["Gal.5.26", "Jas.3.14,Jas.3.16"]
         },
         {
           "Id": 3,
-          "References": ["Psa. 112:9-10", "Neh. 2:10"]
+          "References": ["Ps.112.9-Ps.112.10", "Neh.2.10"]
         },
         {
           "Id": 4,
-          "References": ["Rom. 7:7-8", "Rom. 13:9", "Col. 3:5", "Deut. 5:21"]
+          "References": ["Rom.7.7-Rom.7.8", "Rom.13.9", "Col.3.5", "Deut.5.21"]
         }
       ]
     },
@@ -4873,19 +4873,19 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["James 3:2", "John 15:5", "Rom. 8:3"]
+          "References": ["Jas.3.2", "John.15.5", "Rom.8.3"]
         },
         {
           "Id": 2,
-          "References": ["Eccl. 7:20", "I John 1:8, 10", "Gal. 5:17", "Rom. 7:18-19"]
+          "References": ["Eccl.7.20", "1John.1.8,1John.1.10", "Gal.5.17", "Rom.7.18-Rom.7.19"]
         },
         {
           "Id": 3,
-          "References": ["Gen. 6:5, 8:21"]
+          "References": ["Gen.6.5,Gen.8.21"]
         },
         {
           "Id": 4,
-          "References": ["Rom. 3:9-19", "James 3:2-13"]
+          "References": ["Rom.3.9-Rom.3.19", "Jas.3.2-Jas.3.13"]
         }
       ]
     },
@@ -4897,7 +4897,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["John 19:11", "Ezek. 8:6, 13, 15", "I John 5:16", "Psa. 78:17, 32, 56"]
+          "References": ["John.19.11", "Ezek.8.6,Ezek.8.13,Ezek.8.15", "1John.5.16", "Ps.78.17,Ps.78.32,Ps.78.56"]
         }
       ]
     },
@@ -4909,243 +4909,243 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Jer. 2:8"]
+          "References": ["Jer.2.8"]
         },
         {
           "Id": 2,
-          "References": ["Job 32:7, 9", "Eccl. 4:13"]
+          "References": ["Job.32.7,Job.32.9", "Eccl.4.13"]
         },
         {
           "Id": 3,
-          "References": ["I Kings 11:4, 9"]
+          "References": ["1Kgs.11.4,1Kgs.11.9"]
         },
         {
           "Id": 4,
-          "References": ["II Sam. 12:14", "I Cor. 5:1"]
+          "References": ["2Sam.12.14", "1Cor.5.1"]
         },
         {
           "Id": 5,
-          "References": ["James 4:17", "Luke 12:47-48"]
+          "References": ["Jas.4.17", "Luke.12.47-Luke.12.48"]
         },
         {
           "Id": 6,
-          "References": ["Jer. 5:4-5"]
+          "References": ["Jer.5.4-Jer.5.5"]
         },
         {
           "Id": 7,
-          "References": ["II Sam. 12:7-9", "Ezek. 8:11-12"]
+          "References": ["2Sam.12.7-2Sam.12.9", "Ezek.8.11-Ezek.8.12"]
         },
         {
           "Id": 8,
-          "References": ["Rom. 2:17-24"]
+          "References": ["Rom.2.17-Rom.2.24"]
         },
         {
           "Id": 9,
-          "References": ["Gal. 2:11-14"]
+          "References": ["Gal.2.11-Gal.2.14"]
         },
         {
           "Id": 10,
-          "References": ["Matt. 21:38-39"]
+          "References": ["Matt.21.38-Matt.21.39"]
         },
         {
           "Id": 11,
-          "References": ["I Sam. 2:25", "Acts 5:4", "Psa. 51:4"]
+          "References": ["1Sam.2.25", "Acts.5.4", "Ps.51.4"]
         },
         {
           "Id": 12,
-          "References": ["Rom. 2:4"]
+          "References": ["Rom.2.4"]
         },
         {
           "Id": 13,
-          "References": ["Mal. 1:8, 14"]
+          "References": ["Mal.1.8,Mal.1.14"]
         },
         {
           "Id": 14,
-          "References": ["Heb. 2:2-3", "Heb. 12:25"]
+          "References": ["Heb.2.2-Heb.2.3", "Heb.12.25"]
         },
         {
           "Id": 15,
-          "References": ["Heb. 10:29", "Matt. 12:31-32"]
+          "References": ["Heb.10.29", "Matt.12.31-Matt.12.32"]
         },
         {
           "Id": 16,
-          "References": ["Eph. 4:30"]
+          "References": ["Eph.4.30"]
         },
         {
           "Id": 17,
-          "References": ["Heb. 6:4-6"]
+          "References": ["Heb.6.4-Heb.6.6"]
         },
         {
           "Id": 18,
-          "References": ["Jude 1:8", "Num. 12:8-9", "Isa. 3:5"]
+          "References": ["Jude.1.8", "Num.12.8-Num.12.9", "Isa.3.5"]
         },
         {
           "Id": 19,
-          "References": ["Prov. 30:17", "II Cor. 12:15", "Psa. 55:12-15"]
+          "References": ["Prov.30.17", "2Cor.12.15", "Ps.55.12-Ps.55.15"]
         },
         {
           "Id": 20,
-          "References": ["Zeph. 2:8, 10-11", "Matt. 18:6", "I Cor. 6:8", "Rev. 17:6"]
+          "References": ["Zeph.2.8,Zeph.2.10-Zeph.2.11", "Matt.18.6", "1Cor.6.8", "Rev.17.6"]
         },
         {
           "Id": 21,
-          "References": ["I Cor. 8:11-12", "Rom. 14:13, 15, 21"]
+          "References": ["1Cor.8.11-1Cor.8.12", "Rom.14.13,Rom.14.15,Rom.14.21"]
         },
         {
           "Id": 22,
-          "References": ["Ezek. 13:19", "I Cor. 8:12", "Rev. 18:12-13", "Matt. 23:15"]
+          "References": ["Ezek.13.19", "1Cor.8.12", "Rev.18.12-Rev.18.13", "Matt.23.15"]
         },
         {
           "Id": 23,
-          "References": ["I Thess. 2:15-16", "Josh. 22:20"]
+          "References": ["1Thess.2.15-1Thess.2.16", "Josh.22.20"]
         },
         {
           "Id": 24,
-          "References": ["Prov. 6:30-35"]
+          "References": ["Prov.6.30-Prov.6.35"]
         },
         {
           "Id": 25,
-          "References": ["Ezra 9:10-12", "I Kings 11:9-10"]
+          "References": ["Ezra.9.10-Ezra.9.12", "1Kgs.11.9-1Kgs.11.10"]
         },
         {
           "Id": 26,
-          "References": ["Col. 3:5", "I Tim. 6:10", "Prov. 5:8-12", "Prov. 6:32-33", "Josh. 7:21"]
+          "References": ["Col.3.5", "1Tim.6.1", "Prov.5.8-Prov.5.12", "Prov.6.32-Prov.6.33", "Josh.7.21"]
         },
         {
           "Id": 27,
-          "References": ["James 1:14-15", "Matt. 5:22", "Micah 2:1"]
+          "References": ["Jas.1.14-Jas.1.15", "Matt.5.22", "Mic.2.1"]
         },
         {
           "Id": 28,
-          "References": ["Matt. 18:7", "Rom. 2:23-24"]
+          "References": ["Matt.18.7", "Rom.2.23-Rom.2.24"]
         },
         {
           "Id": 29,
-          "References": ["Deut 22:22, 28-29", "Prov. 6:32-35"]
+          "References": ["Deut.22.22,Deut.22.28-Deut.22.29", "Prov.6.32-Prov.6.35"]
         },
         {
           "Id": 30,
-          "References": ["Matt. 11:21-24", "John 15:22"]
+          "References": ["Matt.11.21-Matt.11.24", "John.15.22"]
         },
         {
           "Id": 31,
-          "References": ["Isa. 1:3", "Deut. 32:6"]
+          "References": ["Isa.1.3", "Deut.32.6"]
         },
         {
           "Id": 32,
-          "References": ["Amos 4:8-11", "Jer. 5:8"]
+          "References": ["Amos.4.8-Amos.4.11", "Jer.5.8"]
         },
         {
           "Id": 33,
-          "References": ["Rom. 1:26-27"]
+          "References": ["Rom.1.26-Rom.1.27"]
         },
         {
           "Id": 34,
-          "References": ["Rom. 1:32", "Dan. 5:22", "Titus 3:10-11"]
+          "References": ["Rom.1.32", "Dan.5.22", "Titus.3.10-Titus.3.11"]
         },
         {
           "Id": 35,
-          "References": ["Prov. 29:1"]
+          "References": ["Prov.29.1"]
         },
         {
           "Id": 36,
-          "References": ["Titus 3:10", "Matt. 18:17"]
+          "References": ["Titus.3.10", "Matt.18.17"]
         },
         {
           "Id": 37,
-          "References": ["Prov. 23:35, 27:22"]
+          "References": ["Prov.23.35,Prov.27.22"]
         },
         {
           "Id": 38,
-          "References": ["Psa. 78:34-37", "Jer. 2:20, 13:5-6, 20-21"]
+          "References": ["Ps.78.34-Ps.78.37", "Jer.2.20,Jer.13.5-Jer.13.6,Jer.13.20-Jer.13.21"]
         },
         {
           "Id": 39,
-          "References": ["Eccl. 5:4-6", "Prov. 20:25"]
+          "References": ["Eccl.5.4-Eccl.5.6", "Prov.20.25"]
         },
         {
           "Id": 40,
-          "References": ["Lev. 26:25"]
+          "References": ["Lev.26.25"]
         },
         {
           "Id": 41,
-          "References": ["Prov. 2:17", "Ezek. 17:18-19"]
+          "References": ["Prov.2.17", "Ezek.17.18-Ezek.17.19"]
         },
         {
           "Id": 42,
-          "References": ["Psa. 36:4"]
+          "References": ["Ps.36.4"]
         },
         {
           "Id": 43,
-          "References": ["Jer. 6:16"]
+          "References": ["Jer.6.16"]
         },
         {
           "Id": 44,
-          "References": ["Num. 15:30", "Exod. 21:14"]
+          "References": ["Num.15.30", "Exod.21.14"]
         },
         {
           "Id": 45,
-          "References": ["Jer. 3:3", "Prov. 7:13"]
+          "References": ["Jer.3.3", "Prov.7.13"]
         },
         {
           "Id": 46,
-          "References": ["Psa. 52:1"]
+          "References": ["Ps.52.1"]
         },
         {
           "Id": 47,
-          "References": ["III John 1:10"]
+          "References": ["3John.1.10"]
         },
         {
           "Id": 48,
-          "References": ["Num. 14:22"]
+          "References": ["Num.14.22"]
         },
         {
           "Id": 49,
-          "References": ["Zech. 7:11-12"]
+          "References": ["Zech.7.11-Zech.7.12"]
         },
         {
           "Id": 50,
-          "References": ["Prov. 2:14"]
+          "References": ["Prov.2.14"]
         },
         {
           "Id": 51,
-          "References": ["Isa. 57:17"]
+          "References": ["Isa.57.17"]
         },
         {
           "Id": 52,
-          "References": ["Jer. 34:8-11", "II Peter 2:20-22"]
+          "References": ["Jer.34.8-Jer.34.11", "2Pet.2.20-2Pet.2.22"]
         },
         {
           "Id": 53,
-          "References": ["II Kings 5:26"]
+          "References": ["2Kgs.5.26"]
         },
         {
           "Id": 54,
-          "References": ["Jer. 7:10", "Isa. 26:10"]
+          "References": ["Jer.7.10", "Isa.26.10"]
         },
         {
           "Id": 55,
-          "References": ["Ezek. 23:37-39"]
+          "References": ["Ezek.23.37-Ezek.23.39"]
         },
         {
           "Id": 56,
-          "References": ["Isa. 58:3-5", "Num. 25:6-7"]
+          "References": ["Isa.58.3-Isa.58.5", "Num.25.6-Num.25.7"]
         },
         {
           "Id": 57,
-          "References": ["I Cor. 11:20-21"]
+          "References": ["1Cor.11.20-1Cor.11.21"]
         },
         {
           "Id": 58,
-          "References": ["Jer. 7:8-10, 14-15", "John 13:27, 30"]
+          "References": ["Jer.7.8-Jer.7.10,Jer.7.14-Jer.7.15", "John.13.27,John.13.30"]
         },
         {
           "Id": 59,
-          "References": ["Ezra 9:13-14"]
+          "References": ["Ezra.9.13-Ezra.9.14"]
         },
         {
           "Id": 60,
-          "References": ["II Sam. 16:22", "I Sam. 2:22-24"]
+          "References": ["2Sam.16.22", "1Sam.2.22-1Sam.2.24"]
         }
       ]
     },
@@ -5157,35 +5157,35 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["James 2:10-11"]
+          "References": ["Jas.2.10-Jas.2.11"]
         },
         {
           "Id": 2,
-          "References": ["Exod. 20:1-2"]
+          "References": ["Exod.20.1-Exod.20.2"]
         },
         {
           "Id": 3,
-          "References": ["Hab. 1:13", "Lev. 10:3", "Lev. 11:44-45"]
+          "References": ["Hab.1.13", "Lev.10.3", "Lev.11.44-Lev.11.45"]
         },
         {
           "Id": 4,
-          "References": ["I John 3:4", "Rom. 7:12"]
+          "References": ["1John.3.4", "Rom.7.12"]
         },
         {
           "Id": 5,
-          "References": ["Eph. 5:6", "Gal. 3:10"]
+          "References": ["Eph.5.6", "Gal.3.10"]
         },
         {
           "Id": 6,
-          "References": ["Lam. 3:39", "Deut. 28:15-68"]
+          "References": ["Lam.3.39", "Deut.28.15-Deut.28.68"]
         },
         {
           "Id": 7,
-          "References": ["Matt. 25:41"]
+          "References": ["Matt.25.41"]
         },
         {
           "Id": 8,
-          "References": ["Heb. 9:22", "I Peter 1:18-19"]
+          "References": ["Heb.9.22", "1Pet.1.18-1Pet.1.19"]
         }
       ]
     },
@@ -5197,11 +5197,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Acts 16:30-31", "Acts 20:21", "Matt. 3:7-8", "Luke 13:3, 5", "John 3:16, 18"]
+          "References": ["Acts.16.30-Acts.16.31", "Acts.20.21", "Matt.3.7-Matt.3.8", "Luke.13.3,Luke.13.5", "John.3.16,John.3.18"]
         },
         {
           "Id": 2,
-          "References": ["Prov. 2:1-5", "Prov. 8:33-36"]
+          "References": ["Prov.2.1-Prov.2.5", "Prov.8.33-Prov.8.36"]
         }
       ]
     },
@@ -5213,7 +5213,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 28:19-20", "Acts 2:42, 46-47"]
+          "References": ["Matt.28.19-Matt.28.20", "Acts.2.42,Acts.2.46-Acts.2.47"]
         }
       ]
     },
@@ -5225,35 +5225,35 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Neh. 8:8", "Acts 26:18", "Psa. 19:8"]
+          "References": ["Neh.8.8", "Acts.26.18", "Ps.19.8"]
         },
         {
           "Id": 2,
-          "References": ["I Cor. 14:24-25", "II Chr. 34:18-19, 26-28"]
+          "References": ["1Cor.14.24-1Cor.14.25", "2Chr.34.18-2Chr.34.19,2Chr.34.26-2Chr.34.28"]
         },
         {
           "Id": 3,
-          "References": ["Acts 2:37, 41", "Acts 8:27-39"]
+          "References": ["Acts.2.37,Acts.2.41", "Acts.8.27-Acts.8.39"]
         },
         {
           "Id": 4,
-          "References": ["II Cor. 3:18"]
+          "References": ["2Cor.3.18"]
         },
         {
           "Id": 5,
-          "References": ["II Cor. 10:4-6", "Rom. 6:17"]
+          "References": ["2Cor.10.4-2Cor.10.6", "Rom.6.17"]
         },
         {
           "Id": 6,
-          "References": ["Matt. 4:4, 7, 10", "Eph. 6:16-17", "Psa. 19:11", "I Cor. 10:11"]
+          "References": ["Matt.4.4,Matt.4.7,Matt.4.10", "Eph.6.16-Eph.6.17", "Ps.19.11", "1Cor.10.11"]
         },
         {
           "Id": 7,
-          "References": ["Acts 20:32", "II Tim. 3:15-17"]
+          "References": ["Acts.20.32", "2Tim.3.15-2Tim.3.17"]
         },
         {
           "Id": 8,
-          "References": ["Rom. 1:16", "Rom. 10:13-17", "Rom. 15:4", "Rom. 16:25", "I Thess. 3:2, 10-11, 13"]
+          "References": ["Rom.1.16", "Rom.10.13-Rom.10.17", "Rom.15.4", "Rom.16.25", "1Thess.3.2,1Thess.3.10-1Thess.3.11,1Thess.3.13"]
         }
       ]
     },
@@ -5265,19 +5265,19 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Deut. 31:9, 11-13", "Neh. 8:2-3", "Neh. 9:3-5"]
+          "References": ["Deut.31.9,Deut.31.11-Deut.31.13", "Neh.8.2-Neh.8.3", "Neh.9.3-Neh.9.5"]
         },
         {
           "Id": 2,
-          "References": ["Deut. 17:19", "Rev. 1:3", "John 5:39", "Isa. 34:16"]
+          "References": ["Deut.17.19", "Rev.1.3", "John.5.39", "Isa.34.16"]
         },
         {
           "Id": 3,
-          "References": ["Deut. 6:6-9", "Gen. 18:17, 19", "Psa. 78:5-7"]
+          "References": ["Deut.6.6-Deut.6.9", "Gen.18.17,Gen.18.19", "Ps.78.5-Ps.78.7"]
         },
         {
           "Id": 4,
-          "References": ["I Cor. 14:6, 9, 11-12, 15-16, 24, 27-28"]
+          "References": ["1Cor.14.6,1Cor.14.9,1Cor.14.11-1Cor.14.12,1Cor.14.15-1Cor.14.16,1Cor.14.24,1Cor.14.27-1Cor.14.28"]
         }
       ]
     },
@@ -5289,43 +5289,43 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Psa. 19:10", "Neh. 8:3-10", "Exod. 24:7", "II Chr. 34:27", "Isa. 66:2"]
+          "References": ["Ps.19.10", "Neh.8.3-Neh.8.10", "Exod.24.7", "2Chr.34.27", "Isa.66.2"]
         },
         {
           "Id": 2,
-          "References": ["II Peter 1:19-21"]
+          "References": ["2Pet.1.19-2Pet.1.21"]
         },
         {
           "Id": 3,
-          "References": ["Luke 24:45", "II Cor. 3:13-16"]
+          "References": ["Luke.24.45", "2Cor.3.13-2Cor.3.16"]
         },
         {
           "Id": 4,
-          "References": ["Deut. 17:10, 20"]
+          "References": ["Deut.17.10,Deut.17.20"]
         },
         {
           "Id": 5,
-          "References": ["Acts 17:11"]
+          "References": ["Acts.17.11"]
         },
         {
           "Id": 6,
-          "References": ["Acts 8:30, 34", "Luke 10:26-28"]
+          "References": ["Acts.8.30,Acts.8.34", "Luke.10.26-Luke.10.28"]
         },
         {
           "Id": 7,
-          "References": ["Psa. 1:2, 119:97"]
+          "References": ["Ps.1.2,Ps.119.97"]
         },
         {
           "Id": 8,
-          "References": ["II Chr. 24:21"]
+          "References": ["2Chr.24.21"]
         },
         {
           "Id": 9,
-          "References": ["Prov. 3:5", "Deut 33:3"]
+          "References": ["Prov.3.5", "Deut.33.3"]
         },
         {
           "Id": 10,
-          "References": ["Prov. 2:1-6", "Psa. 119:18", "Neh. 7:6, 8"]
+          "References": ["Prov.2.1-Prov.2.6", "Ps.119.18", "Neh.7.6,Neh.7.8"]
         }
       ]
     },
@@ -5337,11 +5337,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["I Tim. 3:2, 6", "Eph. 4:8-11", "Hosea 4:6", "Mal. 2:7", "II Cor. 3:6"]
+          "References": ["1Tim.3.2,1Tim.3.6", "Eph.4.8-Eph.4.11", "Hos.4.6", "Mal.2.7", "2Cor.3.6"]
         },
         {
           "Id": 2,
-          "References": ["Jer. 14:15", "Rom. 10:15", "Heb. 5:4", "I Cor. 12:28-29", "I Tim. 3:10", "I Tim. 4:14", "I Tim. 5:22"]
+          "References": ["Jer.14.15", "Rom.10.15", "Heb.5.4", "1Cor.12.28-1Cor.12.29", "1Tim.3.10", "1Tim.4.14", "1Tim.5.22"]
         }
       ]
     },
@@ -5353,71 +5353,71 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Titus 2:1, 8"]
+          "References": ["Titus.2.1,Titus.2.8"]
         },
         {
           "Id": 2,
-          "References": ["Acts 18:25"]
+          "References": ["Acts.18.25"]
         },
         {
           "Id": 3,
-          "References": ["II Tim. 4:2"]
+          "References": ["2Tim.4.2"]
         },
         {
           "Id": 4,
-          "References": ["I Cor. 14:19"]
+          "References": ["1Cor.14.19"]
         },
         {
           "Id": 5,
-          "References": ["I Cor. 2:4"]
+          "References": ["1Cor.2.4"]
         },
         {
           "Id": 6,
-          "References": ["Jer. 23:28", "I Cor. 4:1-2"]
+          "References": ["Jer.23.28", "1Cor.4.1-1Cor.4.2"]
         },
         {
           "Id": 7,
-          "References": ["Acts 20:27"]
+          "References": ["Acts.20.27"]
         },
         {
           "Id": 8,
-          "References": ["Col. 1:28", "II Tim. 2:15"]
+          "References": ["Col.1.28", "2Tim.2.15"]
         },
         {
           "Id": 9,
-          "References": ["I Cor. 3:2", "Heb. 5:12-14", "Luke 12:42"]
+          "References": ["1Cor.3.2", "Heb.5.12-Heb.5.14", "Luke.12.42"]
         },
         {
           "Id": 10,
-          "References": ["Acts 18:25"]
+          "References": ["Acts.18.25"]
         },
         {
           "Id": 11,
-          "References": ["II Cor. 5:13-14", "Phil. 1:15-17"]
+          "References": ["2Cor.5.13-2Cor.5.14", "Phil.1.15-Phil.1.17"]
         },
         {
           "Id": 12,
-          "References": ["Col. 4:12", "II Cor. 12:15"]
+          "References": ["Col.4.12", "2Cor.12.15"]
         },
         {
           "Id": 13,
-          "References": ["II Cor. 2:17", "II Cor. 4:2"]
+          "References": ["2Cor.2.17", "2Cor.4.2"]
         },
         {
           "Id": 14,
-          "References": ["I Thess. 2:4-6", "John 7:18"]
+          "References": ["1Thess.2.4-1Thess.2.6", "John.7.18"]
         },
         {
           "Id": 15,
-          "References": ["I Cor. 9:19-22"]
+          "References": ["1Cor.9.19-1Cor.9.22"]
         },
         {
           "Id": 16,
-          "References": ["II Cor. 12:19", "Eph. 4:12"]
+          "References": ["2Cor.12.19", "Eph.4.12"]
         },
         {
           "Id": 17,
-          "References": ["I Tim. 4:16", "Acts 26:16-18"]
+          "References": ["1Tim.4.16", "Acts.26.16-Acts.26.18"]
         }
       ]
     },
@@ -5429,55 +5429,55 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Prov. 8:34"]
+          "References": ["Prov.8.34"]
         },
         {
           "Id": 2,
-          "References": ["I Peter 2:1-2", "Luke 8:18"]
+          "References": ["1Pet.2.1-1Pet.2.2", "Luke.8.18"]
         },
         {
           "Id": 3,
-          "References": ["Psa. 119:18", "Eph. 6:18-19"]
+          "References": ["Ps.119.18", "Eph.6.18-Eph.6.19"]
         },
         {
           "Id": 4,
-          "References": ["Acts 17:11"]
+          "References": ["Acts.17.11"]
         },
         {
           "Id": 5,
-          "References": ["Heb. 4:2"]
+          "References": ["Heb.4.2"]
         },
         {
           "Id": 6,
-          "References": ["II Thess 2:10"]
+          "References": ["2Thess.2.10"]
         },
         {
           "Id": 7,
-          "References": ["James 1:21"]
+          "References": ["Jas.1.21"]
         },
         {
           "Id": 8,
-          "References": ["Acts 17:11"]
+          "References": ["Acts.17.11"]
         },
         {
           "Id": 9,
-          "References": ["I Thess 2:13"]
+          "References": ["1Thess.2.13"]
         },
         {
           "Id": 10,
-          "References": ["Luke 9:44", "Heb. 2:1"]
+          "References": ["Luke.9.44", "Heb.2.1"]
         },
         {
           "Id": 11,
-          "References": ["Luke 24:14", "Deut 6:6-7"]
+          "References": ["Luke.24.14", "Deut.6.6-Deut.6.7"]
         },
         {
           "Id": 12,
-          "References": ["Prov. 2:1", "Psa. 119:11"]
+          "References": ["Prov.2.1", "Ps.119.11"]
         },
         {
           "Id": 13,
-          "References": ["Luke 8:15", "James 1:25"]
+          "References": ["Luke.8.15", "Jas.1.25"]
         }
       ]
     },
@@ -5489,7 +5489,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["I Peter 3:21", "Acts 8:13, 23", "I Cor. 3:6-7", "I Cor. 12:13"]
+          "References": ["1Pet.3.21", "Acts.8.13,Acts.8.23", "1Cor.3.6-1Cor.3.7", "1Cor.12.13"]
         }
       ]
     },
@@ -5501,35 +5501,35 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Gen. 17:7, 10", "Exod. ch. 12", "Matt. 26:26-28", "Matt. 28:19"]
+          "References": ["Gen.17.7,Gen.17.10", "Exod.12", "Matt.26.26-Matt.26.28", "Matt.28.19"]
         },
         {
           "Id": 2,
-          "References": ["Rom. 4:11", "I Cor. 11:24-25"]
+          "References": ["Rom.4.11", "1Cor.11.24-1Cor.11.25"]
         },
         {
           "Id": 3,
-          "References": ["Rom. 15:8", "Exod. 12:48"]
+          "References": ["Rom.15.8", "Exod.12.48"]
         },
         {
           "Id": 4,
-          "References": ["Acts 2:38", "I Cor. 10:16"]
+          "References": ["Acts.2.38", "1Cor.10.16"]
         },
         {
           "Id": 5,
-          "References": ["Rom. 4:11", "Gal. 3:27"]
+          "References": ["Rom.4.11", "Gal.3.27"]
         },
         {
           "Id": 6,
-          "References": ["Rom. 6:3-4", "I Cor. 10:21"]
+          "References": ["Rom.6.3-Rom.6.4", "1Cor.10.21"]
         },
         {
           "Id": 7,
-          "References": ["Eph. 4:2-5", "I Cor. 12:13"]
+          "References": ["Eph.4.2-Eph.4.5", "1Cor.12.13"]
         },
         {
           "Id": 8,
-          "References": ["Eph. 2:11-12", "Gen. 34:14"]
+          "References": ["Eph.2.11-Eph.2.12", "Gen.34.14"]
         }
       ]
     },
@@ -5541,7 +5541,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 3:11", "I Peter 3:21", "Rom. 2:28-29"]
+          "References": ["Matt.3.11", "1Pet.3.21", "Rom.2.28-Rom.2.29"]
         }
       ]
     },
@@ -5553,7 +5553,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 26:26-28", "Matt. 28:19", "I Cor. 11:20, 23"]
+          "References": ["Matt.26.26-Matt.26.28", "Matt.28.19", "1Cor.11.20,1Cor.11.23"]
         }
       ]
     },
@@ -5565,35 +5565,35 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 28:19"]
+          "References": ["Matt.28.19"]
         },
         {
           "Id": 2,
-          "References": ["Gal. 3:27"]
+          "References": ["Gal.3.27"]
         },
         {
           "Id": 3,
-          "References": ["Mark 1:4", "Rev. 1:5"]
+          "References": ["Mark.1.4", "Rev.1.5"]
         },
         {
           "Id": 4,
-          "References": ["Titus 3:5", "Eph. 5:26"]
+          "References": ["Titus.3.5", "Eph.5.26"]
         },
         {
           "Id": 5,
-          "References": ["Gal. 3:26-27"]
+          "References": ["Gal.3.26-Gal.3.27"]
         },
         {
           "Id": 6,
-          "References": ["I Cor. 15:29", "Rom. 6:5"]
+          "References": ["1Cor.15.29", "Rom.6.5"]
         },
         {
           "Id": 7,
-          "References": ["I Cor. 12:13"]
+          "References": ["1Cor.12.13"]
         },
         {
           "Id": 8,
-          "References": ["Rom. 6:4"]
+          "References": ["Rom.6.4"]
         }
       ]
     },
@@ -5605,11 +5605,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Acts 2:38", "Acts 8:36-37"]
+          "References": ["Acts.2.38", "Acts.8.36-Acts.8.37"]
         },
         {
           "Id": 2,
-          "References": ["Gen. 17:7, 9", "Gal. 3:9, 14", "Col. 2:11-12", "Acts 2:38-39", "Rom. 4:11-12", "Rom. 11:16", "I Cor. 7:14", "Matt 28:19", "Luke 18:15-16"]
+          "References": ["Gen.17.7,Gen.17.9", "Gal.3.9,Gal.3.14", "Col.2.11-Col.2.12", "Acts.2.38-Acts.2.39", "Rom.4.11-Rom.4.12", "Rom.11.16", "1Cor.7.14", "Matt.28.19", "Luke.18.15-Luke.18.16"]
         }
       ]
     },
@@ -5621,39 +5621,39 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Col. 2:11-12", "Rom. 6:4, 6, 11"]
+          "References": ["Col.2.11-Col.2.12", "Rom.6.4,Rom.6.6,Rom.6.11"]
         },
         {
           "Id": 2,
-          "References": ["Rom. 6:3-5"]
+          "References": ["Rom.6.3-Rom.6.5"]
         },
         {
           "Id": 3,
-          "References": ["I Cor. 1:11-13", "Rom. 6:2-3"]
+          "References": ["1Cor.1.11-1Cor.1.13", "Rom.6.2-Rom.6.3"]
         },
         {
           "Id": 4,
-          "References": ["Rom. 4:11-12", "I Peter 3:21"]
+          "References": ["Rom.4.11-Rom.4.12", "1Pet.3.21"]
         },
         {
           "Id": 5,
-          "References": ["Rom. 6:3-5"]
+          "References": ["Rom.6.3-Rom.6.5"]
         },
         {
           "Id": 6,
-          "References": ["Gal. 3:26-27"]
+          "References": ["Gal.3.26-Gal.3.27"]
         },
         {
           "Id": 7,
-          "References": ["Rom. 6:22"]
+          "References": ["Rom.6.22"]
         },
         {
           "Id": 8,
-          "References": ["Acts 2:38"]
+          "References": ["Acts.2.38"]
         },
         {
           "Id": 9,
-          "References": ["I Cor. 12:13, 25-27"]
+          "References": ["1Cor.12.13,1Cor.12.25-1Cor.12.27"]
         }
       ]
     },
@@ -5665,27 +5665,27 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Luke 22:20"]
+          "References": ["Luke.22.20"]
         },
         {
           "Id": 2,
-          "References": ["Matt. 26:26-28", "I Cor. 11:13-26"]
+          "References": ["Matt.26.26-Matt.26.28", "1Cor.11.13-1Cor.11.26"]
         },
         {
           "Id": 3,
-          "References": ["I Cor. 10:16"]
+          "References": ["1Cor.10.16"]
         },
         {
           "Id": 4,
-          "References": ["I Cor. 11:24"]
+          "References": ["1Cor.11.24"]
         },
         {
           "Id": 5,
-          "References": ["I Cor. 10:14-16, 21"]
+          "References": ["1Cor.10.14-1Cor.10.16,1Cor.10.21"]
         },
         {
           "Id": 6,
-          "References": ["I Cor. 10:17"]
+          "References": ["1Cor.10.17"]
         }
       ]
     },
@@ -5697,7 +5697,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["I Cor. 11:23-24", "Matt. 26:26-28", "Mark 14:22-24", "Luke 22:19-20"]
+          "References": ["1Cor.11.23-1Cor.11.24", "Matt.26.26-Matt.26.28", "Mark.14.22-Mark.14.24", "Luke.22.19-Luke.22.20"]
         }
       ]
     },
@@ -5709,19 +5709,19 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Acts 3:21"]
+          "References": ["Acts.3.21"]
         },
         {
           "Id": 2,
-          "References": ["Matt. 26:26, 28"]
+          "References": ["Matt.26.26,Matt.26.28"]
         },
         {
           "Id": 3,
-          "References": ["I Cor. 11:24-29"]
+          "References": ["1Cor.11.24-1Cor.11.29"]
         },
         {
           "Id": 4,
-          "References": ["I Cor. 10:16"]
+          "References": ["1Cor.10.16"]
         }
       ]
     },
@@ -5733,59 +5733,59 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["I Cor. 11:28"]
+          "References": ["1Cor.11.28"]
         },
         {
           "Id": 2,
-          "References": ["II Cor. 13:5"]
+          "References": ["2Cor.13.5"]
         },
         {
           "Id": 3,
-          "References": ["I Cor. 5:7", "Exod. 12:15"]
+          "References": ["1Cor.5.7", "Exod.12.15"]
         },
         {
           "Id": 4,
-          "References": ["I Cor. 11:29"]
+          "References": ["1Cor.11.29"]
         },
         {
           "Id": 5,
-          "References": ["I Cor. 13:5", "Matt. 26:28"]
+          "References": ["1Cor.13.5", "Matt.26.28"]
         },
         {
           "Id": 6,
-          "References": ["Zech. 12:10", "I Cor. 11:31"]
+          "References": ["Zech.12.10", "1Cor.11.31"]
         },
         {
           "Id": 7,
-          "References": ["I Cor. 10:16-17", "Acts 2:46-47"]
+          "References": ["1Cor.10.16-1Cor.10.17", "Acts.2.46-Acts.2.47"]
         },
         {
           "Id": 8,
-          "References": ["I Cor. 5:8", "I Cor. 11:18, 20"]
+          "References": ["1Cor.5.8", "1Cor.11.18,1Cor.11.20"]
         },
         {
           "Id": 9,
-          "References": ["Matt. 5:23-24"]
+          "References": ["Matt.5.23-Matt.5.24"]
         },
         {
           "Id": 10,
-          "References": ["Isa .55:1", "John 7:37"]
+          "References": ["Isa.55.1", "John.7.37"]
         },
         {
           "Id": 11,
-          "References": ["I Cor. 5:7-8"]
+          "References": ["1Cor.5.7-1Cor.5.8"]
         },
         {
           "Id": 12,
-          "References": ["I Cor. 11:25-26, 28", "Heb. 10:21-22, 24", "Psa. 26:6"]
+          "References": ["1Cor.11.25-1Cor.11.26,1Cor.11.28", "Heb.10.21-Heb.10.22,Heb.10.24", "Ps.26.6"]
         },
         {
           "Id": 13,
-          "References": ["I Cor. 11:24-25"]
+          "References": ["1Cor.11.24-1Cor.11.25"]
         },
         {
           "Id": 14,
-          "References": ["II Chr. 30:18-19", "Matt. 26:26"]
+          "References": ["2Chr.30.18-2Chr.30.19", "Matt.26.26"]
         }
       ]
     },
@@ -5797,35 +5797,35 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Isa. 1:10", "I John 5:13", "Psa. 77:1-12", "ch 88", "Jonah 2:4, 7"]
+          "References": ["Isa.1.10", "1John.5.13", "Ps.88", "Ps.77.1-Ps.77.12", "Jonah.2.4,Jonah.2.7"]
         },
         {
           "Id": 2,
-          "References": ["Isa. 54:7-10", "Matt. 5:3-4", "Psa. 31:22", "Psa. 73:13, 22-23"]
+          "References": ["Isa.54.7-Isa.54.10", "Matt.5.3-Matt.5.4", "Ps.31.22", "Ps.73.13,Ps.73.22-Ps.73.23"]
         },
         {
           "Id": 3,
-          "References": ["Phil 3:8-9", "Psa. 10:17", "Psa. 42:1-2, 5, 11"]
+          "References": ["Phil.3.8-Phil.3.9", "Ps.10.17", "Ps.42.1-Ps.42.2,Ps.42.5,Ps.42.11"]
         },
         {
           "Id": 4,
-          "References": ["II Tim. 2:19", "Isa. 1:10", "Psa. 66:18-20"]
+          "References": ["2Tim.2.19", "Isa.1.10", "Ps.66.18-Ps.66.20"]
         },
         {
           "Id": 5,
-          "References": ["Isa. 40:11, 29, 31", "Matt. 11:28", "Matt. 12:20", "Matt. 26:28"]
+          "References": ["Isa.40.11,Isa.40.29,Isa.40.31", "Matt.11.28", "Matt.12.20", "Matt.26.28"]
         },
         {
           "Id": 6,
-          "References": ["Mark 9:24"]
+          "References": ["Mark.9.24"]
         },
         {
           "Id": 7,
-          "References": ["Acts 2:37, 16:30"]
+          "References": ["Acts.2.37,Acts.16.30"]
         },
         {
           "Id": 8,
-          "References": ["Rom. 4:11", "I Cor. 11:28"]
+          "References": ["Rom.4.11", "1Cor.11.28"]
         }
       ]
     },
@@ -5837,11 +5837,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["I Cor. ch. 5", "I Cor. 11:27-31", "Matt. 7:6", "Jude 1:23", "I Tim. 5:22"]
+          "References": ["1Cor.5", "1Cor.11.27-1Cor.11.31", "Matt.7.6", "Jude.1.23", "1Tim.5.22"]
         },
         {
           "Id": 2,
-          "References": ["II Cor. 2:7"]
+          "References": ["2Cor.2.7"]
         }
       ]
     },
@@ -5853,59 +5853,59 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Lev. 10:3", "Heb. 12:18", "Psa. 5:7", "I Cor. 11:17, 26-27"]
+          "References": ["Lev.10.3", "Heb.12.18", "Ps.5.7", "1Cor.11.17,1Cor.11.26-1Cor.11.27"]
         },
         {
           "Id": 2,
-          "References": ["Exod. 24:8", "Matt. 26:28"]
+          "References": ["Exod.24.8", "Matt.26.28"]
         },
         {
           "Id": 3,
-          "References": ["I Cor. 11:29"]
+          "References": ["1Cor.11.29"]
         },
         {
           "Id": 4,
-          "References": ["Luke 22:19"]
+          "References": ["Luke.22.19"]
         },
         {
           "Id": 5,
-          "References": ["I Cor. 10:3-5, 11, 14", "I Cor. 11:26"]
+          "References": ["1Cor.10.3-1Cor.10.5,1Cor.10.11,1Cor.10.14", "1Cor.11.26"]
         },
         {
           "Id": 6,
-          "References": ["I Cor. 11:31"]
+          "References": ["1Cor.11.31"]
         },
         {
           "Id": 7,
-          "References": ["Zech. 12:10"]
+          "References": ["Zech.12.10"]
         },
         {
           "Id": 8,
-          "References": ["Rev. 22:17"]
+          "References": ["Rev.22.17"]
         },
         {
           "Id": 9,
-          "References": ["John 6:35"]
+          "References": ["John.6.35"]
         },
         {
           "Id": 10,
-          "References": ["John 1:16"]
+          "References": ["John.1.16"]
         },
         {
           "Id": 11,
-          "References": ["Phil. 1:16"]
+          "References": ["Phil.1.16"]
         },
         {
           "Id": 12,
-          "References": ["Psa. 63:4-5", "II Chr. 30:21"]
+          "References": ["Ps.63.4-Ps.63.5", "2Chr.30.21"]
         },
         {
           "Id": 13,
-          "References": ["Psa. 22:26"]
+          "References": ["Ps.22.26"]
         },
         {
           "Id": 14,
-          "References": ["Jer. 1:5", "Psa. 1:5"]
+          "References": ["Jer.1.5", "Ps.1.5"]
         }
       ]
     },
@@ -5917,43 +5917,43 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Psa. 28:7, 85:8", "I Cor. 11:17, 30-31"]
+          "References": ["Ps.28.7,Ps.85.8", "1Cor.11.17,1Cor.11.30-1Cor.11.31"]
         },
         {
           "Id": 2,
-          "References": ["II Chr. 30:21-16", "Acts 2:42, 46"]
+          "References": ["2Chr.30.21,2Chr.30.16", "Acts.2.42,Acts.2.46"]
         },
         {
           "Id": 3,
-          "References": ["Psa. 36:10", "Song of Sol. 3:4", "I Chr. 29:18"]
+          "References": ["Ps.36.10", "Song.3.4", "1Chr.29.18"]
         },
         {
           "Id": 4,
-          "References": ["I Cor. 10:3-5, 12"]
+          "References": ["1Cor.10.3-1Cor.10.5,1Cor.10.12"]
         },
         {
           "Id": 5,
-          "References": ["Psa. 50:14"]
+          "References": ["Ps.50.14"]
         },
         {
           "Id": 6,
-          "References": ["I Cor. 11:25-26", "Acts 2:42, 46"]
+          "References": ["1Cor.11.25-1Cor.11.26", "Acts.2.42,Acts.2.46"]
         },
         {
           "Id": 7,
-          "References": ["Song of Sol. 5:1-6", "Eccl. 5:1-6"]
+          "References": ["Song.5.1-Song.5.6", "Eccl.5.1-Eccl.5.6"]
         },
         {
           "Id": 8,
-          "References": ["Psa. 42:5, 8", "Psa. 43:3-5", "Psa. 123:1-2"]
+          "References": ["Ps.42.5,Ps.42.8", "Ps.43.3-Ps.43.5", "Ps.123.1-Ps.123.2"]
         },
         {
           "Id": 9,
-          "References": ["II Chr. 30:18-19", "Isa. 1:16, 18"]
+          "References": ["2Chr.30.18-2Chr.30.19", "Isa.1.16,Isa.1.18"]
         },
         {
           "Id": 10,
-          "References": ["II Cor. 7:11", "I Chr. 15:12-14"]
+          "References": ["2Cor.7.11", "1Chr.15.12-1Chr.15.14"]
         }
       ]
     },
@@ -5965,23 +5965,23 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 28:19", "I Cor. 11:23"]
+          "References": ["Matt.28.19", "1Cor.11.23"]
         },
         {
           "Id": 2,
-          "References": ["Rom. 6:3-4", "I Cor. 10:16"]
+          "References": ["Rom.6.3-Rom.6.4", "1Cor.10.16"]
         },
         {
           "Id": 3,
-          "References": ["Rom. 4:11", "Col. 2:12", "Matt. 26:27-28"]
+          "References": ["Rom.4.11", "Col.2.12", "Matt.26.27-Matt.26.28"]
         },
         {
           "Id": 4,
-          "References": ["John 1:33", "Matt. 28:19", "I Cor. 4:1", "I Cor. 11:23", "Heb. 5:4"]
+          "References": ["John.1.33", "Matt.28.19", "1Cor.4.1", "1Cor.11.23", "Heb.5.4"]
         },
         {
           "Id": 5,
-          "References": ["Matt. 28:19-20", "I Cor. 11:26"]
+          "References": ["Matt.28.19-Matt.28.20", "1Cor.11.26"]
         }
       ]
     },
@@ -5993,23 +5993,23 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 3:11", "Titus 3:5", "Gal. 3:27"]
+          "References": ["Matt.3.11", "Titus.3.5", "Gal.3.27"]
         },
         {
           "Id": 2,
-          "References": ["Gen. 17:7, 9", "Acts 2:38-39", "I Cor. 7:14"]
+          "References": ["Gen.17.7,Gen.17.9", "Acts.2.38-Acts.2.39", "1Cor.7.14"]
         },
         {
           "Id": 3,
-          "References": ["I Cor. 11:23-26"]
+          "References": ["1Cor.11.23-1Cor.11.26"]
         },
         {
           "Id": 4,
-          "References": ["I Cor. 10:16"]
+          "References": ["1Cor.10.16"]
         },
         {
           "Id": 5,
-          "References": ["I Cor. 11:28-29"]
+          "References": ["1Cor.11.28-1Cor.11.29"]
         }
       ]
     },
@@ -6021,23 +6021,23 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Psa. 62:8"]
+          "References": ["Ps.62.8"]
         },
         {
           "Id": 2,
-          "References": ["John 16:23"]
+          "References": ["John.16.23"]
         },
         {
           "Id": 3,
-          "References": ["Rom. 8:26"]
+          "References": ["Rom.8.26"]
         },
         {
           "Id": 4,
-          "References": ["Psa. 32:5-6", "Dan. 9:4"]
+          "References": ["Ps.32.5-Ps.32.6", "Dan.9.4"]
         },
         {
           "Id": 5,
-          "References": ["Phil. 4:6"]
+          "References": ["Phil.4.6"]
         }
       ]
     },
@@ -6049,39 +6049,39 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["I Kings 8:39", "Acts 1:24", "Rom. 8:27"]
+          "References": ["1Kgs.8.39", "Acts.1.24", "Rom.8.27"]
         },
         {
           "Id": 2,
-          "References": ["Psa. 65:2"]
+          "References": ["Ps.65.2"]
         },
         {
           "Id": 3,
-          "References": ["Micah 7:18"]
+          "References": ["Mic.7.18"]
         },
         {
           "Id": 4,
-          "References": ["Psa. 145:18-19"]
+          "References": ["Ps.145.18-Ps.145.19"]
         },
         {
           "Id": 5,
-          "References": ["Rom. 10:14"]
+          "References": ["Rom.10.14"]
         },
         {
           "Id": 6,
-          "References": ["Matt. 4:10"]
+          "References": ["Matt.4.10"]
         },
         {
           "Id": 7,
-          "References": ["I Cor. 1:2"]
+          "References": ["1Cor.1.2"]
         },
         {
           "Id": 8,
-          "References": ["Psa. 50:15"]
+          "References": ["Ps.50.15"]
         },
         {
           "Id": 9,
-          "References": ["Rom. 10:14"]
+          "References": ["Rom.10.14"]
         }
       ]
     },
@@ -6093,15 +6093,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["John 14:13-14, 16:24", "Dan. 9:17"]
+          "References": ["John.14.13-John.14.14,John.16.24", "Dan.9.17"]
         },
         {
           "Id": 2,
-          "References": ["Matt. 7:21"]
+          "References": ["Matt.7.21"]
         },
         {
           "Id": 3,
-          "References": ["Heb. 4:14-16", "I John 5:13-15"]
+          "References": ["Heb.4.14-Heb.4.16", "1John.5.13-1John.5.15"]
         }
       ]
     },
@@ -6113,15 +6113,15 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["John 14:6", "Isa. 59:2", "Eph. 3:12"]
+          "References": ["John.14.6", "Isa.59.2", "Eph.3.12"]
         },
         {
           "Id": 2,
-          "References": ["John 6:27", "Heb. 7:25-27", "I Tim. 2:5"]
+          "References": ["John.6.27", "Heb.7.25-Heb.7.27", "1Tim.2.5"]
         },
         {
           "Id": 3,
-          "References": ["Col. 3:17", "Heb. 13:15"]
+          "References": ["Col.3.17", "Heb.13.15"]
         }
       ]
     },
@@ -6133,7 +6133,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Rom. 8:26-27", "Psa. 10:17", "Zech. 12:10"]
+          "References": ["Rom.8.26-Rom.8.27", "Ps.10.17", "Zech.12.10"]
         }
       ]
     },
@@ -6145,43 +6145,43 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Eph. 6:18", "Psa. 28:9"]
+          "References": ["Eph.6.18", "Ps.28.9"]
         },
         {
           "Id": 2,
-          "References": ["I Tim. 2:1-2"]
+          "References": ["1Tim.2.1-1Tim.2.2"]
         },
         {
           "Id": 3,
-          "References": ["Col. 4:3"]
+          "References": ["Col.4.3"]
         },
         {
           "Id": 4,
-          "References": ["Gen. 32:11"]
+          "References": ["Gen.32.11"]
         },
         {
           "Id": 5,
-          "References": ["James 5:16"]
+          "References": ["Jas.5.16"]
         },
         {
           "Id": 6,
-          "References": ["Matt. 5:44"]
+          "References": ["Matt.5.44"]
         },
         {
           "Id": 7,
-          "References": ["I Tim. 2:1-2"]
+          "References": ["1Tim.2.1-1Tim.2.2"]
         },
         {
           "Id": 8,
-          "References": ["John 17:20", "II Sam. 7:29"]
+          "References": ["John.17.20", "2Sam.7.29"]
         },
         {
           "Id": 9,
-          "References": ["II Sam. 12:21-23"]
+          "References": ["2Sam.12.21-2Sam.12.23"]
         },
         {
           "Id": 10,
-          "References": ["I John 5:16"]
+          "References": ["1John.5.16"]
         }
       ]
     },
@@ -6193,23 +6193,23 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 6:9"]
+          "References": ["Matt.6.9"]
         },
         {
           "Id": 2,
-          "References": ["Psa. 51:18, 122:6"]
+          "References": ["Ps.51.18,Ps.122.6"]
         },
         {
           "Id": 3,
-          "References": ["Matt. 7:11"]
+          "References": ["Matt.7.11"]
         },
         {
           "Id": 4,
-          "References": ["Psa. 125:4"]
+          "References": ["Ps.125.4"]
         },
         {
           "Id": 5,
-          "References": ["I John 5:14"]
+          "References": ["1John.5.14"]
         }
       ]
     },
@@ -6221,63 +6221,63 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Eccl. 5:1"]
+          "References": ["Eccl.5.1"]
         },
         {
           "Id": 2,
-          "References": ["Gen. 18:27", "Gen. 32:10"]
+          "References": ["Gen.18.27", "Gen.32.10"]
         },
         {
           "Id": 3,
-          "References": ["Luke 15:17-19"]
+          "References": ["Luke.15.17-Luke.15.19"]
         },
         {
           "Id": 4,
-          "References": ["Luke 18:13-14"]
+          "References": ["Luke.18.13-Luke.18.14"]
         },
         {
           "Id": 5,
-          "References": ["Psa. 51:17"]
+          "References": ["Ps.51.17"]
         },
         {
           "Id": 6,
-          "References": ["Phil. 4:6"]
+          "References": ["Phil.4.6"]
         },
         {
           "Id": 7,
-          "References": ["I Sam. 1:15, 2:1"]
+          "References": ["1Sam.1.15,1Sam.2.1"]
         },
         {
           "Id": 8,
-          "References": ["I Cor. 14:15"]
+          "References": ["1Cor.14.15"]
         },
         {
           "Id": 9,
-          "References": ["Mark 11:24", "James 1:6"]
+          "References": ["Mark.11.24", "Jas.1.6"]
         },
         {
           "Id": 10,
-          "References": ["Psa. 17:1", "Psa. 145:18"]
+          "References": ["Ps.17.1", "Ps.145.18"]
         },
         {
           "Id": 11,
-          "References": ["James 5:16"]
+          "References": ["Jas.5.16"]
         },
         {
           "Id": 12,
-          "References": ["I Tim. 2:8"]
+          "References": ["1Tim.2.8"]
         },
         {
           "Id": 13,
-          "References": ["Eph. 6:18"]
+          "References": ["Eph.6.18"]
         },
         {
           "Id": 14,
-          "References": ["Micah 7:7"]
+          "References": ["Mic.7.7"]
         },
         {
           "Id": 15,
-          "References": ["Matt. 26:39"]
+          "References": ["Matt.26.39"]
         }
       ]
     },
@@ -6289,11 +6289,11 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["I John 5:14"]
+          "References": ["1John.5.14"]
         },
         {
           "Id": 2,
-          "References": ["Matt. 6:2-13", "Luke 11:2-4"]
+          "References": ["Matt.6.2-Matt.6.13", "Luke.11.2-Luke.11.4"]
         }
       ]
     },
@@ -6305,7 +6305,7 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 6:9", "Luke 11:2"]
+          "References": ["Matt.6.9", "Luke.11.2"]
         }
       ]
     },
@@ -6324,27 +6324,27 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 6:9"]
+          "References": ["Matt.6.9"]
         },
         {
           "Id": 2,
-          "References": ["Luke 11:13", "Rom. 8:15"]
+          "References": ["Luke.11.13", "Rom.8.15"]
         },
         {
           "Id": 3,
-          "References": ["Isa. 64:9"]
+          "References": ["Isa.64.9"]
         },
         {
           "Id": 4,
-          "References": ["Psa. 123:1", "Lam. 3:41"]
+          "References": ["Ps.123.1", "Lam.3.41"]
         },
         {
           "Id": 5,
-          "References": ["Isa. 63:15-16", "Neh. 1:4-6"]
+          "References": ["Isa.63.15-Isa.63.16", "Neh.1.4-Neh.1.6"]
         },
         {
           "Id": 6,
-          "References": ["Acts 12:5"]
+          "References": ["Acts.12.5"]
         }
       ]
     },
@@ -6356,63 +6356,63 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 6:9"]
+          "References": ["Matt.6.9"]
         },
         {
           "Id": 2,
-          "References": ["II Cor. 3:5", "Psa. 51:15"]
+          "References": ["2Cor.3.5", "Ps.51.15"]
         },
         {
           "Id": 3,
-          "References": ["Psa. 67:2-3"]
+          "References": ["Ps.67.2-Ps.67.3"]
         },
         {
           "Id": 4,
-          "References": ["Psa. 83:18"]
+          "References": ["Ps.83.18"]
         },
         {
           "Id": 5,
-          "References": ["Psa. 86:10-13, 15"]
+          "References": ["Ps.86.10-Ps.86.13,Ps.86.15"]
         },
         {
           "Id": 6,
-          "References": ["II Thess. 3:1", "Psa. 138:1-3", "Psa. 147:19-20", "II Cor. 2:14-15"]
+          "References": ["2Thess.3.1", "Ps.138.1-Ps.138.3", "Ps.147.19-Ps.147.20", "2Cor.2.14-2Cor.2.15"]
         },
         {
           "Id": 7,
-          "References": ["Psa. ch. 8", "ch. 145"]
+          "References": ["Ps.145", "Ps.8"]
         },
         {
           "Id": 8,
-          "References": ["Psa. 19:14", "Psa. 103:1"]
+          "References": ["Ps.19.14", "Ps.103.1"]
         },
         {
           "Id": 9,
-          "References": ["Phil. 1:9, 11"]
+          "References": ["Phil.1.9,Phil.1.11"]
         },
         {
           "Id": 10,
-          "References": ["Psa. 67:1-4"]
+          "References": ["Ps.67.1-Ps.67.4"]
         },
         {
           "Id": 11,
-          "References": ["Eph. 1:17-18"]
+          "References": ["Eph.1.17-Eph.1.18"]
         },
         {
           "Id": 12,
-          "References": ["Psa. 97:7"]
+          "References": ["Ps.97.7"]
         },
         {
           "Id": 13,
-          "References": ["Psa. 74:18, 22-23"]
+          "References": ["Ps.74.18,Ps.74.22-Ps.74.23"]
         },
         {
           "Id": 14,
-          "References": ["II Kings 19:15-16"]
+          "References": ["2Kgs.19.15-2Kgs.19.16"]
         },
         {
           "Id": 15,
-          "References": ["II Chr. 20:6, 10-12", "Psa. ch. 83", "Psa. 140:4, 8"]
+          "References": ["2Chr.20.6,2Chr.20.10-2Chr.20.12", "Ps.83", "Ps.140.4,Ps.140.8"]
         }
       ]
     },
@@ -6424,55 +6424,55 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 6:10"]
+          "References": ["Matt.6.10"]
         },
         {
           "Id": 2,
-          "References": ["Eph. 2:2-3"]
+          "References": ["Eph.2.2-Eph.2.3"]
         },
         {
           "Id": 3,
-          "References": ["Psa. 68:1, 18", "Rev. 12:10-11"]
+          "References": ["Ps.68.1,Ps.68.18", "Rev.12.10-Rev.12.11"]
         },
         {
           "Id": 4,
-          "References": ["II Thess. 3:1"]
+          "References": ["2Thess.3.1"]
         },
         {
           "Id": 5,
-          "References": ["Rom. 10:1"]
+          "References": ["Rom.10.1"]
         },
         {
           "Id": 6,
-          "References": ["John 17:9, 20", "Rom. 11:25-26", "Psa. ch. 67"]
+          "References": ["John.17.9,John.17.20", "Rom.11.25-Rom.11.26", "Ps.67"]
         },
         {
           "Id": 7,
-          "References": ["Matt. 9:38", "II Thess. 3:1"]
+          "References": ["Matt.9.38", "2Thess.3.1"]
         },
         {
           "Id": 8,
-          "References": ["Mal. 1:11", "Zeph. 3:9"]
+          "References": ["Mal.1.11", "Zeph.3.9"]
         },
         {
           "Id": 9,
-          "References": ["I Tim. 2:1-2"]
+          "References": ["1Tim.2.1-1Tim.2.2"]
         },
         {
           "Id": 10,
-          "References": ["Acts 4:29-30", "Eph. 6:18-20", "Rom. 15:29-30, 32", "II Thess. 1:11", "II Thess. 2:16-17"]
+          "References": ["Acts.4.29-Acts.4.30", "Eph.6.18-Eph.6.20", "Rom.15.29-Rom.15.30,Rom.15.32", "2Thess.1.11", "2Thess.2.16-2Thess.2.17"]
         },
         {
           "Id": 11,
-          "References": ["Eph. 3:14-20"]
+          "References": ["Eph.3.14-Eph.3.20"]
         },
         {
           "Id": 12,
-          "References": ["Rev. 22:20"]
+          "References": ["Rev.22.20"]
         },
         {
           "Id": 13,
-          "References": ["Isa. 64:1-2", "Rev. 4:8-11"]
+          "References": ["Isa.64.1-Isa.64.2", "Rev.4.8-Rev.4.11"]
         }
       ]
     },
@@ -6484,75 +6484,75 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 6:10"]
+          "References": ["Matt.6.10"]
         },
         {
           "Id": 2,
-          "References": ["Rom. 7:18", "Job 21:14", "I Cor. 2:14"]
+          "References": ["Rom.7.18", "Job.21.14", "1Cor.2.14"]
         },
         {
           "Id": 3,
-          "References": ["Rom. 8:7"]
+          "References": ["Rom.8.7"]
         },
         {
           "Id": 4,
-          "References": ["Exod. 17:7", "Num. 14:2"]
+          "References": ["Exod.17.7", "Num.14.2"]
         },
         {
           "Id": 5,
-          "References": ["Eph. 2:2"]
+          "References": ["Eph.2.2"]
         },
         {
           "Id": 6,
-          "References": ["Eph. 1:17-18"]
+          "References": ["Eph.1.17-Eph.1.18"]
         },
         {
           "Id": 7,
-          "References": ["Eph. 3:16"]
+          "References": ["Eph.3.16"]
         },
         {
           "Id": 8,
-          "References": ["Matt. 26:40-41"]
+          "References": ["Matt.26.40-Matt.26.41"]
         },
         {
           "Id": 9,
-          "References": ["Jer. 31:18-19"]
+          "References": ["Jer.31.18-Jer.31.19"]
         },
         {
           "Id": 10,
-          "References": ["Psa. 119:1, 8, 35-36", "Acts 21:14"]
+          "References": ["Ps.119.1,Ps.119.8,Ps.119.35-Ps.119.36", "Acts.21.14"]
         },
         {
           "Id": 11,
-          "References": ["Micah 6:8"]
+          "References": ["Mic.6.8"]
         },
         {
           "Id": 12,
-          "References": ["Psa. 100:2", "Job 1:21", "II Sam. 15:25-26"]
+          "References": ["Ps.100.2", "Job.1.21", "2Sam.15.25-2Sam.15.26"]
         },
         {
           "Id": 13,
-          "References": ["Isa. 38:3"]
+          "References": ["Isa.38.3"]
         },
         {
           "Id": 14,
-          "References": ["Psa. 119:4-5"]
+          "References": ["Ps.119.4-Ps.119.5"]
         },
         {
           "Id": 15,
-          "References": ["Rom. 12:11"]
+          "References": ["Rom.12.11"]
         },
         {
           "Id": 16,
-          "References": ["Psa. 119:80"]
+          "References": ["Ps.119.80"]
         },
         {
           "Id": 17,
-          "References": ["Psa. 119:112"]
+          "References": ["Ps.119.112"]
         },
         {
           "Id": 18,
-          "References": ["Isa. 6:2-3", "Psa. 103:20-21", "Matt. 18:10"]
+          "References": ["Isa.6.2-Isa.6.3", "Ps.103.20-Ps.103.21", "Matt.18.10"]
         }
       ]
     },
@@ -6564,51 +6564,51 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 6:11"]
+          "References": ["Matt.6.11"]
         },
         {
           "Id": 2,
-          "References": ["Gen. 2:17, 3:17", "Rom. 8:20-22", "Jer. 5:25", "Deut. 28:15-68"]
+          "References": ["Gen.2.17,Gen.3.17", "Rom.8.20-Rom.8.22", "Jer.5.25", "Deut.28.15-Deut.28.68"]
         },
         {
           "Id": 3,
-          "References": ["Deut. 8:3"]
+          "References": ["Deut.8.3"]
         },
         {
           "Id": 4,
-          "References": ["Gen. 32:10"]
+          "References": ["Gen.32.10"]
         },
         {
           "Id": 5,
-          "References": ["Deut. 8:17-18"]
+          "References": ["Deut.8.17-Deut.8.18"]
         },
         {
           "Id": 6,
-          "References": ["Jer. 6:13", "Mark 7:21-22"]
+          "References": ["Jer.6.13", "Mark.7.21-Mark.7.22"]
         },
         {
           "Id": 7,
-          "References": ["Hosea 12:7"]
+          "References": ["Hos.12.7"]
         },
         {
           "Id": 8,
-          "References": ["James 4:3"]
+          "References": ["Jas.4.3"]
         },
         {
           "Id": 9,
-          "References": ["Gen. 28:20", "Gen. 43:12-14", "Eph. 4:28", "II Thess. 3:11-12", "Phil. 4:6"]
+          "References": ["Gen.28.20", "Gen.43.12-Gen.43.14", "Eph.4.28", "2Thess.3.11-2Thess.3.12", "Phil.4.6"]
         },
         {
           "Id": 10,
-          "References": ["I Tim. 4:3-5"]
+          "References": ["1Tim.4.3-1Tim.4.5"]
         },
         {
           "Id": 11,
-          "References": ["I Tim. 6:6-8"]
+          "References": ["1Tim.6.6-1Tim.6.8"]
         },
         {
           "Id": 12,
-          "References": ["Prov. 30:8-9"]
+          "References": ["Prov.30.8-Prov.30.9"]
         }
       ]
     },
@@ -6620,35 +6620,35 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 6:12"]
+          "References": ["Matt.6.12"]
         },
         {
           "Id": 2,
-          "References": ["Rom. 3:9-22", "Matt. 18:24-25", "Psa. 130:3-4"]
+          "References": ["Rom.3.9-Rom.3.22", "Matt.18.24-Matt.18.25", "Ps.130.3-Ps.130.4"]
         },
         {
           "Id": 3,
-          "References": ["Rom. 3:24-26", "Heb. 9:22"]
+          "References": ["Rom.3.24-Rom.3.26", "Heb.9.22"]
         },
         {
           "Id": 4,
-          "References": ["Eph. 1:6-7"]
+          "References": ["Eph.1.6-Eph.1.7"]
         },
         {
           "Id": 5,
-          "References": ["II Peter 1:2"]
+          "References": ["2Pet.1.2"]
         },
         {
           "Id": 6,
-          "References": ["Hosea 14:2", "Jer. 14:7"]
+          "References": ["Hos.14.2", "Jer.14.7"]
         },
         {
           "Id": 7,
-          "References": ["Rom. 15:13", "Psa. 51:7-10, 12"]
+          "References": ["Rom.15.13", "Ps.51.7-Ps.51.10,Ps.51.12"]
         },
         {
           "Id": 8,
-          "References": ["Luke 11:4", "Matt. 6:14-15", "Matt. 18:35"]
+          "References": ["Luke.11.4", "Matt.6.14-Matt.6.15", "Matt.18.35"]
         }
       ]
     },
@@ -6660,91 +6660,91 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 6:13"]
+          "References": ["Matt.6.13"]
         },
         {
           "Id": 2,
-          "References": ["II Chr. 32:31"]
+          "References": ["2Chr.32.31"]
         },
         {
           "Id": 3,
-          "References": ["I Chr. 21:1"]
+          "References": ["1Chr.21.1"]
         },
         {
           "Id": 4,
-          "References": ["Luke 21:34", "Mark 4:19"]
+          "References": ["Luke.21.34", "Mark.4.19"]
         },
         {
           "Id": 5,
-          "References": ["James 1:14"]
+          "References": ["Jas.1.14"]
         },
         {
           "Id": 6,
-          "References": ["Gal. 5:17"]
+          "References": ["Gal.5.17"]
         },
         {
           "Id": 7,
-          "References": ["Matt. 26:41"]
+          "References": ["Matt.26.41"]
         },
         {
           "Id": 8,
-          "References": ["Matt. 26:69-72", "Gal. 2:11-14", "II Chr. 18:3", "II Chr. 19:2"]
+          "References": ["Matt.26.69-Matt.26.72", "Gal.2.11-Gal.2.14", "2Chr.18.3", "2Chr.19.2"]
         },
         {
           "Id": 9,
-          "References": ["Rom. 7:23-24", "I Chr. 21:1-4", "II Chr. 16:7-10"]
+          "References": ["Rom.7.23-Rom.7.24", "1Chr.21.1-1Chr.21.4", "2Chr.16.7-2Chr.16.10"]
         },
         {
           "Id": 10,
-          "References": ["Psa. 81:11-12"]
+          "References": ["Ps.81.11-Ps.81.12"]
         },
         {
           "Id": 11,
-          "References": ["John 17:15"]
+          "References": ["John.17.15"]
         },
         {
           "Id": 12,
-          "References": ["Psa. 51:10", "Psa. 119:133"]
+          "References": ["Ps.51.10", "Ps.119.133"]
         },
         {
           "Id": 13,
-          "References": ["II Cor. 12:7-8"]
+          "References": ["2Cor.12.7-2Cor.12.8"]
         },
         {
           "Id": 14,
-          "References": ["I Cor. 10:12-13"]
+          "References": ["1Cor.10.12-1Cor.10.13"]
         },
         {
           "Id": 15,
-          "References": ["Heb. 13:20-21"]
+          "References": ["Heb.13.20-Heb.13.21"]
         },
         {
           "Id": 16,
-          "References": ["Matt. 26:41", "Psa. 19:13"]
+          "References": ["Matt.26.41", "Ps.19.13"]
         },
         {
           "Id": 17,
-          "References": ["Eph. 3:14-17", "I Thess. 3:13", "Jude 1:24"]
+          "References": ["Eph.3.14-Eph.3.17", "1Thess.3.13", "Jude.1.24"]
         },
         {
           "Id": 18,
-          "References": ["Psa. 51:12"]
+          "References": ["Ps.51.12"]
         },
         {
           "Id": 19,
-          "References": ["I Peter 5:8-10"]
+          "References": ["1Pet.5.8-1Pet.5.10"]
         },
         {
           "Id": 20,
-          "References": ["II Cor. 13:7, 9"]
+          "References": ["2Cor.13.7,2Cor.13.9"]
         },
         {
           "Id": 21,
-          "References": ["Rom. 16:20", "Zech. 3:2", "Luke 22:31-32"]
+          "References": ["Rom.16.20", "Zech.3.2", "Luke.22.31-Luke.22.32"]
         },
         {
           "Id": 22,
-          "References": ["John 17:15", "I Thess. 5:23"]
+          "References": ["John.17.15", "1Thess.5.23"]
         }
       ]
     },
@@ -6756,39 +6756,39 @@
       "Proofs": [
         {
           "Id": 1,
-          "References": ["Matt. 6:13"]
+          "References": ["Matt.6.13"]
         },
         {
           "Id": 2,
-          "References": ["Rom. 15:30"]
+          "References": ["Rom.15.30"]
         },
         {
           "Id": 3,
-          "References": ["Dan. 9:4, 7-9, 16-19"]
+          "References": ["Dan.9.4,Dan.9.7-Dan.9.9,Dan.9.16-Dan.9.19"]
         },
         {
           "Id": 4,
-          "References": ["Phil. 4:6"]
+          "References": ["Phil.4.6"]
         },
         {
           "Id": 5,
-          "References": ["I Chr. 29:10-13"]
+          "References": ["1Chr.29.10-1Chr.29.13"]
         },
         {
           "Id": 6,
-          "References": ["Eph. 3:20-21", "Luke 11:13"]
+          "References": ["Eph.3.20-Eph.3.21", "Luke.11.13"]
         },
         {
           "Id": 7,
-          "References": ["II Chr. 20:6, 11"]
+          "References": ["2Chr.20.6,2Chr.20.11"]
         },
         {
           "Id": 8,
-          "References": ["II Chr. 14:11"]
+          "References": ["2Chr.14.11"]
         },
         {
           "Id": 9,
-          "References": ["I Cor. 14:16", "Rev. 22:20-21"]
+          "References": ["1Cor.14.16", "Rev.22.20-Rev.22.21"]
         }
       ]
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "devDependencies": {
         "@vitest/coverage-c8": "^0.29.2",
+        "bible-passage-reference-parser": "^2.0.1",
         "jsonschema": "^1.4.1",
         "typescript": "^4.9.3",
         "typescript-json-schema": "^0.55.0",
@@ -635,6 +636,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/bible-passage-reference-parser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/bible-passage-reference-parser/-/bible-passage-reference-parser-2.0.1.tgz",
+      "integrity": "sha512-A/W1ElN+BQP4Xww/2tpuFx3lGGz6nPQz/rdqNL9pbN2Pk0f5rqOj2/VKRO8DgPcH7NrnawZeajJBCakPL/QXWQ==",
       "dev": true
     },
     "node_modules/brace-expansion": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "devDependencies": {
     "@vitest/coverage-c8": "^0.29.2",
+    "bible-passage-reference-parser": "^2.0.1",
     "jsonschema": "^1.4.1",
     "typescript": "^4.9.3",
     "typescript-json-schema": "^0.55.0",

--- a/tests/all.test.ts
+++ b/tests/all.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect } from "vitest"
 import { resolve } from "path";
 import { readdirSync, readFileSync } from "fs"
+import { bcv_parser as BcvParcer } from "bible-passage-reference-parser/js/en_bcv_parser"
 import { Validator } from "jsonschema"
 import TJS from "typescript-json-schema"
 import type { CreedDocument, Proof } from "./types.ts"
@@ -34,6 +35,8 @@ const settings: TJS.PartialArgs = {
   required: true,
 }
 
+const referenceParser = new BcvParcer()
+
 const schemas = {}
 for(const typeName of ["Metadata", "Proof", "Creed", "Canon", "Confession", "Catechism", "HenrysCatechism"])
   schemas[typeName] = TJS.generateSchema(program, typeName, settings)
@@ -62,10 +65,16 @@ const testDocument = (document: CreedDocument<any>, filename: string) => {
 }
 
 const testReferences = (proof: any) => {
-  for(const reference of proof.References)
-    test(`${reference} is valid`, async () => {
+  for(const reference of proof.References) {
+    test(`${reference} is a single reference`, async () => {
       expect(reference).not.toContain(';')
     })
+
+    test(`${reference} is OSIS`, async () => {
+      const osis = referenceParser.parse(reference).osis()
+      expect(reference).toEqual(osis)
+    })
+  }
 }
 
 const testProofs = (item: any) => {


### PR DESCRIPTION
#### Summary

Adds `bible-passage-reference-parser` as a dev dependency, and includes a new test for each reference to check if they are in OSIS format. (#24)